### PR TITLE
Add a key-row control that sends typed characters to the terminal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,7 @@ project follows [Semantic Versioning](https://semver.org/).
 
 ### Added
 
-- A key-row **A** control opens the phone keyboard without focusing the prompt
-  composer, so typed characters are sent to the terminal as keys. This lets
-  modal editors such as pi-vim leave normal mode (`i`) before a prompt is
-  submitted.
+- Key-row **A** focuses the existing key capture so typed characters go to the terminal without using the prompt composer.
 
 ## [0.16.4] - 2026-08-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ project follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- A key-row **A** control opens the phone keyboard without focusing the prompt
+  composer, so typed characters are sent to the terminal as keys. This lets
+  modal editors such as pi-vim leave normal mode (`i`) before a prompt is
+  submitted.
+
 ## [0.16.4] - 2026-08-18
 
 ### Fixed

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -593,6 +593,7 @@ textarea { min-height: 6.5rem; resize: vertical; }
 .term-keys .spacer { flex: 1; }
 .modifier-menu, .arrow-menu { position: relative; }
 .modifier-key-input { border: 0; height: 1px; left: 50%; opacity: 0; padding: 0; pointer-events: none; position: absolute; width: 1px; }
+.modifier-key-input.char-armed { font-size: 16px; height: 16px; left: 0; opacity: .01; pointer-events: auto; width: 100%; }
 .modifier-menu .button[aria-pressed='true'] { background: var(--primary); color: var(--primary-foreground); }
 .arrow-popup { background: var(--card); border: 1px solid var(--border); border-radius: .7rem; bottom: 2.8rem; display: grid; gap: .2rem; grid-template-columns: repeat(3, 2.3rem); padding: .35rem; position: absolute; right: 0; z-index: 10; }
 .arrow-popup button { background: var(--secondary); border: 0; border-radius: .4rem; color: var(--foreground); height: 2.3rem; }

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -593,7 +593,6 @@ textarea { min-height: 6.5rem; resize: vertical; }
 .term-keys .spacer { flex: 1; }
 .modifier-menu, .arrow-menu { position: relative; }
 .modifier-key-input { border: 0; height: 1px; left: 50%; opacity: 0; padding: 0; pointer-events: none; position: absolute; width: 1px; }
-.modifier-key-input.char-armed { font-size: 16px; height: 16px; left: 0; opacity: .01; pointer-events: auto; width: 100%; }
 .modifier-menu .button[aria-pressed='true'] { background: var(--primary); color: var(--primary-foreground); }
 .arrow-popup { background: var(--card); border: 1px solid var(--border); border-radius: .7rem; bottom: 2.8rem; display: grid; gap: .2rem; grid-template-columns: repeat(3, 2.3rem); padding: .35rem; position: absolute; right: 0; z-index: 10; }
 .arrow-popup button { background: var(--secondary); border: 0; border-radius: .4rem; color: var(--foreground); height: 2.3rem; }

--- a/frontend/src/components/TerminalView.svelte
+++ b/frontend/src/components/TerminalView.svelte
@@ -121,7 +121,6 @@
   let ctrlArmed = $state(false);
   let shiftArmed = $state(false);
   let altArmed = $state(false);
-  let charsArmed = $state(false);
   let keyFeedback = $state('');
   let keyFeedbackError = $state(false);
   let keySending = $state(false);
@@ -209,9 +208,7 @@
   ].filter(Boolean).join('+'));
   const keyControlStatus = $derived(armedModifierLabel
     ? `${armedModifierLabel} armed${keyFeedback ? ` · ${keyFeedback}` : ' — choose a key or type a character'}`
-    : charsArmed
-      ? `Type characters${keyFeedback ? ` · ${keyFeedback}` : ' — keys go to the terminal'}`
-      : keyFeedback);
+    : keyFeedback);
   const agentResponseCopySupported = $derived.by(() => {
     const connection = $connections.get(agent.relay_id);
     return Boolean(
@@ -1174,7 +1171,6 @@
   }
   function toggleModifier(which: 'ctrl' | 'alt' | 'shift') {
     arrowsOpen = false;
-    charsArmed = false;
     if (which === 'ctrl') ctrlArmed = !ctrlArmed;
     else if (which === 'alt') altArmed = !altArmed;
     else shiftArmed = !shiftArmed;
@@ -1188,15 +1184,9 @@
 
   function toggleChars() {
     arrowsOpen = false;
-    if (charsArmed) {
-      charsArmed = false;
-      modifierInputElement.blur();
-      return;
-    }
     ctrlArmed = false;
     altArmed = false;
     shiftArmed = false;
-    charsArmed = true;
     modifierInputElement.value = '';
     modifierInputElement.focus();
   }
@@ -1229,7 +1219,6 @@
     ctrlArmed = false;
     altArmed = false;
     shiftArmed = false;
-    charsArmed = false;
     modifierInputElement.blur();
   }
 
@@ -1262,7 +1251,6 @@
         ctrlArmed = false;
         altArmed = false;
         shiftArmed = false;
-        charsArmed = false;
       }
     });
   }
@@ -1765,13 +1753,10 @@
         <input
           id="modifier-key-input"
           class="modifier-key-input"
-          class:char-armed={charsArmed}
           bind:this={modifierInputElement}
           aria-label="Modifier shortcut character"
           autocomplete="off"
           autocapitalize="none"
-          autocorrect="off"
-          inputmode="text"
           maxlength="1"
           spellcheck="false"
           oninput={modifierInput}
@@ -1782,9 +1767,7 @@
           variant="secondary"
           size="sm"
           aria-controls="modifier-key-input"
-          aria-pressed={charsArmed}
           aria-label="Type characters"
-          title="Open the keyboard and send each character to the terminal"
           onpointerdown={(event) => event.preventDefault()}
           onclick={toggleChars}
         >A</Button>

--- a/frontend/src/components/TerminalView.svelte
+++ b/frontend/src/components/TerminalView.svelte
@@ -121,6 +121,7 @@
   let ctrlArmed = $state(false);
   let shiftArmed = $state(false);
   let altArmed = $state(false);
+  let charsArmed = $state(false);
   let keyFeedback = $state('');
   let keyFeedbackError = $state(false);
   let keySending = $state(false);
@@ -208,7 +209,9 @@
   ].filter(Boolean).join('+'));
   const keyControlStatus = $derived(armedModifierLabel
     ? `${armedModifierLabel} armed${keyFeedback ? ` · ${keyFeedback}` : ' — choose a key or type a character'}`
-    : keyFeedback);
+    : charsArmed
+      ? `Type characters${keyFeedback ? ` · ${keyFeedback}` : ' — keys go to the terminal'}`
+      : keyFeedback);
   const agentResponseCopySupported = $derived.by(() => {
     const connection = $connections.get(agent.relay_id);
     return Boolean(
@@ -1171,6 +1174,7 @@
   }
   function toggleModifier(which: 'ctrl' | 'alt' | 'shift') {
     arrowsOpen = false;
+    charsArmed = false;
     if (which === 'ctrl') ctrlArmed = !ctrlArmed;
     else if (which === 'alt') altArmed = !altArmed;
     else shiftArmed = !shiftArmed;
@@ -1180,6 +1184,21 @@
     } else {
       modifierInputElement.blur();
     }
+  }
+
+  function toggleChars() {
+    arrowsOpen = false;
+    if (charsArmed) {
+      charsArmed = false;
+      modifierInputElement.blur();
+      return;
+    }
+    ctrlArmed = false;
+    altArmed = false;
+    shiftArmed = false;
+    charsArmed = true;
+    modifierInputElement.value = '';
+    modifierInputElement.focus();
   }
 
   function toggleCtrl() {
@@ -1210,6 +1229,7 @@
     ctrlArmed = false;
     altArmed = false;
     shiftArmed = false;
+    charsArmed = false;
     modifierInputElement.blur();
   }
 
@@ -1242,6 +1262,7 @@
         ctrlArmed = false;
         altArmed = false;
         shiftArmed = false;
+        charsArmed = false;
       }
     });
   }
@@ -1744,16 +1765,29 @@
         <input
           id="modifier-key-input"
           class="modifier-key-input"
+          class:char-armed={charsArmed}
           bind:this={modifierInputElement}
           aria-label="Modifier shortcut character"
           autocomplete="off"
           autocapitalize="none"
+          autocorrect="off"
+          inputmode="text"
           maxlength="1"
           spellcheck="false"
           oninput={modifierInput}
           onkeydown={modifierKeydown}
           onblur={modifierBlur}
         />
+        <Button
+          variant="secondary"
+          size="sm"
+          aria-controls="modifier-key-input"
+          aria-pressed={charsArmed}
+          aria-label="Type characters"
+          title="Open the keyboard and send each character to the terminal"
+          onpointerdown={(event) => event.preventDefault()}
+          onclick={toggleChars}
+        >A</Button>
         <Button
           variant="secondary"
           size="sm"

--- a/frontend/tests/browser/mobile-journeys.spec.ts
+++ b/frontend/tests/browser/mobile-journeys.spec.ts
@@ -3692,7 +3692,6 @@ test('refreshes agents on return home and preserves shared terminal behavior', a
   await expect(ctrlKey).toHaveAttribute('aria-pressed', 'false');
   await expect(shiftKey).toHaveAttribute('aria-pressed', 'false');
   await expect(altKey).toHaveAttribute('aria-pressed', 'false');
-  await expect(typeChars).toHaveAttribute('aria-pressed', 'false');
   await expect(attachImage).not.toContainText('▧');
   await expect(arrowKeys).not.toContainText('⌨');
   await arrowKeys.click();
@@ -3791,14 +3790,12 @@ test('refreshes agents on return home and preserves shared terminal behavior', a
   await expect(shiftKey).toHaveAttribute('aria-pressed', 'false');
   await expect(modifierLetter).not.toBeFocused();
   await typeChars.click();
-  await expect(typeChars).toHaveAttribute('aria-pressed', 'true');
   await expect(modifierLetter).toBeFocused();
   await expect(page.getByRole('combobox', { name: 'Prompt' })).not.toBeFocused();
   await modifierLetter.press('i');
   await expect.poll(async () => (await commands(page))
     .filter((command) => command.type === 'send_keys'
       && JSON.stringify(command.keys) === JSON.stringify(['i'])).length).toBe(1);
-  await expect(typeChars).toHaveAttribute('aria-pressed', 'true');
   await expect(modifierLetter).toBeFocused();
   await expect(page.getByRole('combobox', { name: 'Prompt' })).not.toBeFocused();
   const refreshesBeforeBack = (await commands(page)).filter((command) => command.type === 'refresh_agents').length;

--- a/frontend/tests/browser/mobile-journeys.spec.ts
+++ b/frontend/tests/browser/mobile-journeys.spec.ts
@@ -3678,6 +3678,7 @@ test('refreshes agents on return home and preserves shared terminal behavior', a
   const ctrlKey = page.getByRole('button', { name: 'Ctrl', exact: true });
   const shiftKey = page.getByRole('button', { name: 'Shift', exact: true });
   const altKey = page.getByRole('button', { name: 'Alt', exact: true });
+  const typeChars = page.getByRole('button', { name: 'Type characters' });
   const modifierLetter = page.getByRole('textbox', { name: 'Modifier shortcut character' });
   const copyOutput = page.getByRole('button', { name: 'Copy', exact: true });
   await expect(attachImage.locator('svg')).toBeVisible();
@@ -3686,10 +3687,12 @@ test('refreshes agents on return home and preserves shared terminal behavior', a
   await expect(ctrlKey).toBeVisible();
   await expect(shiftKey).toBeVisible();
   await expect(altKey).toBeVisible();
+  await expect(typeChars).toBeVisible();
   await expect(copyOutput).toBeVisible();
   await expect(ctrlKey).toHaveAttribute('aria-pressed', 'false');
   await expect(shiftKey).toHaveAttribute('aria-pressed', 'false');
   await expect(altKey).toHaveAttribute('aria-pressed', 'false');
+  await expect(typeChars).toHaveAttribute('aria-pressed', 'false');
   await expect(attachImage).not.toContainText('▧');
   await expect(arrowKeys).not.toContainText('⌨');
   await arrowKeys.click();
@@ -3787,6 +3790,17 @@ test('refreshes agents on return home and preserves shared terminal behavior', a
   await page.getByRole('combobox', { name: 'Prompt' }).focus();
   await expect(shiftKey).toHaveAttribute('aria-pressed', 'false');
   await expect(modifierLetter).not.toBeFocused();
+  await typeChars.click();
+  await expect(typeChars).toHaveAttribute('aria-pressed', 'true');
+  await expect(modifierLetter).toBeFocused();
+  await expect(page.getByRole('combobox', { name: 'Prompt' })).not.toBeFocused();
+  await modifierLetter.press('i');
+  await expect.poll(async () => (await commands(page))
+    .filter((command) => command.type === 'send_keys'
+      && JSON.stringify(command.keys) === JSON.stringify(['i'])).length).toBe(1);
+  await expect(typeChars).toHaveAttribute('aria-pressed', 'true');
+  await expect(modifierLetter).toBeFocused();
+  await expect(page.getByRole('combobox', { name: 'Prompt' })).not.toBeFocused();
   const refreshesBeforeBack = (await commands(page)).filter((command) => command.type === 'refresh_agents').length;
   await page.getByRole('button', { name: 'Back' }).click();
   await expect.poll(async () => (await commands(page)).filter((command) => command.type === 'refresh_agents').length)

--- a/frontend/tests/unit/components.test.ts
+++ b/frontend/tests/unit/components.test.ts
@@ -105,6 +105,39 @@ describe('accessible Svelte interactions', () => {
     vi.restoreAllMocks();
   });
 
+  it('sends typed characters as keys without focusing the prompt', async () => {
+    const user = userEvent.setup();
+    const agent: Agent = {
+      relay_id: 'fedora', relay_label: 'Fedora', raw_pane_id: 'w1:p2', pane_id: 'fedora::w1:p2',
+      project: 'relay', agent: 'pi', status: 'idle', cwd: '/home/test/relay',
+    };
+    vi.spyOn(relayStore, 'readPane').mockImplementation(() => undefined);
+    vi.spyOn(relayStore, 'loadSlashCommands').mockResolvedValue({ commands: [], truncated: false });
+    const send = vi.spyOn(relayStore, 'sendToAgent').mockResolvedValue({
+      type: 'command_result', request_id: 'keys-1', ok: true,
+    });
+    render(TerminalView, {
+      agent,
+      allAgents: [agent],
+      frame: { paneId: agent.pane_id, content: 'ready', format: 'plain' },
+      responding: new Set<string>(),
+    });
+
+    const composer = screen.getByRole('combobox', { name: 'Prompt' });
+    const capture = screen.getByRole('textbox', { name: 'Modifier shortcut character' });
+    await user.click(screen.getByRole('button', { name: 'Type characters' }));
+    expect(screen.getByRole('button', { name: 'Type characters' })).toHaveAttribute('aria-pressed', 'true');
+    expect(capture).toHaveFocus();
+    expect(composer).not.toHaveFocus();
+    await user.type(capture, 'i');
+    expect(send).toHaveBeenCalledWith(agent, {
+      type: 'send_keys', keys: ['i'], activity_label: 'i',
+    });
+    expect(composer).toHaveValue('');
+    expect(composer).not.toHaveFocus();
+    vi.restoreAllMocks();
+  });
+
   it('opens agents and submits approval buttons by role', async () => {
     const user = userEvent.setup();
     const onopen = vi.fn();

--- a/frontend/tests/unit/components.test.ts
+++ b/frontend/tests/unit/components.test.ts
@@ -126,7 +126,6 @@ describe('accessible Svelte interactions', () => {
     const composer = screen.getByRole('combobox', { name: 'Prompt' });
     const capture = screen.getByRole('textbox', { name: 'Modifier shortcut character' });
     await user.click(screen.getByRole('button', { name: 'Type characters' }));
-    expect(screen.getByRole('button', { name: 'Type characters' })).toHaveAttribute('aria-pressed', 'true');
     expect(capture).toHaveFocus();
     expect(composer).not.toHaveFocus();
     await user.type(capture, 'i');


### PR DESCRIPTION
## Why

`Send` uses `herdr agent prompt`, which is bracketed paste + Enter. In a modal editor (pi-vim in normal mode) that paste is not the `i` command, so neither insert mode nor prompt submit happens.

The phone already has Esc/Tab/Enter and Ctrl/Alt/Shift chords. It had no way to send a bare character without focusing the composer.

## What

An **A** button on the key row focuses the existing hidden capture input. The phone keyboard opens, the prompt composer stays unfocused, and each typed character is sent as `send_keys`.

Tap **A** again, Esc, or the composer to leave the mode.

## Test

- unit: Type characters, type `i`, composer stays empty/unfocused, `send_keys ['i']`
- browser: same path in the shared terminal-controls journey