### PR TITLE
fix: keep Claude user turns whose content is a block array

### DIFF
--- a/internal/conversation/reader.go
+++ b/internal/conversation/reader.go
@@ -549,7 +549,21 @@ func parseClaudeRecord(record map[string]any) (string, string) {
 		return role, humanClaudeText(raw)
 	}
 	if role == "user" {
-		return "", ""
+		// Filter per block, not on the joined string: humanClaudeText anchors its
+		// envelope checks on the start of what it is given, so joining first
+		// would let a <system-reminder> in any block after the first survive
+		// into the phone's conversation view.
+		blocks := textBlockList(content)
+		kept := make([]string, 0, len(blocks))
+		for _, block := range blocks {
+			if text := humanClaudeText(block); strings.TrimSpace(text) != "" {
+				kept = append(kept, text)
+			}
+		}
+		if len(kept) == 0 {
+			return "", ""
+		}
+		return role, strings.Join(kept, "\n")
 	}
 	return role, textBlocks(content)
 }
@@ -621,9 +635,16 @@ func textBlocks(value any) string {
 	if text, ok := value.(string); ok {
 		return text
 	}
+	return strings.Join(textBlockList(value), "\n")
+}
+
+// textBlockList reports the text carried by each text-like block separately.
+// Callers that filter per block need the boundaries: joining first would let an
+// envelope in a later block escape a prefix test anchored on the whole string.
+func textBlockList(value any) []string {
 	blocks, ok := value.([]any)
 	if !ok {
-		return ""
+		return nil
 	}
 	texts := make([]string, 0, len(blocks))
 	for _, rawBlock := range blocks {
@@ -639,7 +660,7 @@ func textBlocks(value any) string {
 			texts = append(texts, text)
 		}
 	}
-	return strings.Join(texts, "\n")
+	return texts
 }
 
 func sanitizeText(text string) string {

--- a/internal/conversation/reader_test.go
+++ b/internal/conversation/reader_test.go
@@ -175,3 +175,219 @@ func TestClaudeConversationAssociatesToolResultsWithCallingTurn(t *testing.T) {
 		t.Fatalf("tool = %#v", tool)
 	}
 }
+
+func TestClaudeConversationKeepsArrayShapedUserPrompts(t *testing.T) {
+	reader, home := testReader(t)
+	path := filepath.Join(home, ".claude", "projects", "-work", testSessionID+".jsonl")
+	writeRows(t, path,
+		map[string]any{
+			"type": "user", "timestamp": "2026-08-12T10:00:00Z",
+			"message": map[string]any{"content": []any{map[string]any{"type": "text", "text": "hi"}}},
+		},
+	)
+
+	page, err := reader.Read("claude", testSessionID, "", 80)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !page.Available || page.Total != 1 || len(page.Entries) != 1 {
+		t.Fatalf("page = %#v, want one visible turn", page)
+	}
+	if page.Entries[0].Role != "user" || page.Entries[0].Text != "hi" {
+		t.Fatalf("entries = %#v", page.Entries)
+	}
+}
+
+func TestClaudeConversationDropsToolResultOnlyUserRowButKeepsToolOutput(t *testing.T) {
+	reader, home := testReader(t)
+	path := filepath.Join(home, ".claude", "projects", "-work", testSessionID+".jsonl")
+	writeRows(t, path,
+		map[string]any{
+			"type": "assistant", "timestamp": "2026-08-12T10:00:00Z",
+			"message": map[string]any{"content": []any{
+				map[string]any{"type": "text", "text": "I will inspect the file."},
+				map[string]any{"type": "tool_use", "id": "tool-1", "name": "Read", "input": map[string]any{"path": "README.md"}},
+			}},
+		},
+		map[string]any{
+			"type": "user", "timestamp": "2026-08-12T10:00:01Z",
+			"message": map[string]any{"content": []any{
+				map[string]any{"type": "tool_result", "tool_use_id": "tool-1", "content": "file contents"},
+			}},
+		},
+	)
+
+	page, err := reader.Read("claude", testSessionID, "", 80)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if page.Total != 1 || len(page.Entries) != 1 || page.Entries[0].Role != "assistant" {
+		t.Fatalf("entries = %#v, want only the calling assistant turn", page.Entries)
+	}
+	if len(page.Entries[0].Tools) != 1 || page.Entries[0].Tools[0].Output != "file contents" {
+		t.Fatalf("tools = %#v, want the tool output attached", page.Entries[0].Tools)
+	}
+}
+
+func TestClaudeConversationFiltersArrayShapedEnvelopes(t *testing.T) {
+	reader, home := testReader(t)
+	path := filepath.Join(home, ".claude", "projects", "-work", testSessionID+".jsonl")
+	writeRows(t, path,
+		map[string]any{
+			"type": "user", "timestamp": "2026-08-12T10:00:00Z",
+			"message": map[string]any{"content": []any{
+				map[string]any{"type": "text", "text": "<system-reminder>hidden</system-reminder>"},
+			}},
+		},
+	)
+
+	page, err := reader.Read("claude", testSessionID, "", 80)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if page.Total != 0 || len(page.Entries) != 0 {
+		t.Fatalf("entries = %#v, want the injected envelope filtered", page.Entries)
+	}
+}
+
+func TestClaudeConversationKeepsOnlyTextFromMixedUserBlocks(t *testing.T) {
+	reader, home := testReader(t)
+	path := filepath.Join(home, ".claude", "projects", "-work", testSessionID+".jsonl")
+	writeRows(t, path,
+		map[string]any{
+			"type": "assistant", "timestamp": "2026-08-12T10:00:00Z",
+			"message": map[string]any{"content": []any{
+				map[string]any{"type": "tool_use", "id": "tool-1", "name": "Read", "input": map[string]any{"path": "README.md"}},
+			}},
+		},
+		map[string]any{
+			"type": "user", "timestamp": "2026-08-12T10:00:01Z",
+			"message": map[string]any{"content": []any{
+				map[string]any{"type": "tool_result", "tool_use_id": "tool-1", "content": "secret file contents"},
+				map[string]any{"type": "text", "text": "now summarise it"},
+			}},
+		},
+	)
+
+	page, err := reader.Read("claude", testSessionID, "", 80)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if page.Total != 2 || len(page.Entries) != 2 {
+		t.Fatalf("entries = %#v, want the assistant call and the user prompt", page.Entries)
+	}
+	entry := page.Entries[1]
+	if entry.Role != "user" || entry.Text != "now summarise it" {
+		t.Fatalf("entry = %#v, want only the text block", entry)
+	}
+	if strings.Contains(entry.Text, "secret file contents") || strings.Contains(entry.Text, "tool_result") {
+		t.Fatalf("entry text leaked tool_result payload: %q", entry.Text)
+	}
+}
+
+func TestClaudeConversationDropsEmptyArrayUserRow(t *testing.T) {
+	reader, home := testReader(t)
+	path := filepath.Join(home, ".claude", "projects", "-work", testSessionID+".jsonl")
+	writeRows(t, path,
+		map[string]any{
+			"type": "user", "timestamp": "2026-08-12T10:00:00Z",
+			"message": map[string]any{"content": []any{}},
+		},
+	)
+
+	page, err := reader.Read("claude", testSessionID, "", 80)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if page.Total != 0 || len(page.Entries) != 0 {
+		t.Fatalf("entries = %#v, want no turn for an empty content array", page.Entries)
+	}
+}
+
+func TestClaudeConversationRendersArrayShapedSlashCommands(t *testing.T) {
+	reader, home := testReader(t)
+	path := filepath.Join(home, ".claude", "projects", "-work", testSessionID+".jsonl")
+	writeRows(t, path,
+		map[string]any{
+			"type": "user", "timestamp": "2026-08-12T10:00:00Z",
+			"message": map[string]any{"content": []any{map[string]any{
+				"type": "text",
+				"text": "<command-name>/clear</command-name><command-args>x</command-args>",
+			}}},
+		},
+		map[string]any{
+			"type": "user", "timestamp": "2026-08-12T10:00:01Z",
+			"message": map[string]any{"content": "<command-name>/clear</command-name><command-args>x</command-args>"},
+		},
+	)
+
+	page, err := reader.Read("claude", testSessionID, "", 80)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if page.Total != 2 || len(page.Entries) != 2 {
+		t.Fatalf("entries = %#v, want both command rows", page.Entries)
+	}
+	if page.Entries[0].Text != "/clear x" || page.Entries[1].Text != "/clear x" {
+		t.Fatalf("entries = %#v, want array and string forms rendered identically", page.Entries)
+	}
+}
+
+// Regression guard for the per-block envelope filter. Before array-shaped user
+// records were parsed at all they were dropped wholesale, so an injected
+// <system-reminder> could not reach the phone. Parsing them made it reachable:
+// humanClaudeText anchors its envelope checks on the start of the string it is
+// given, so filtering the JOINED block text lets an envelope in any block after
+// the first through. Filtering must happen per block.
+func TestClaudeConversationDropsEnvelopeBlocksAfterTheFirst(t *testing.T) {
+	reader, home := testReader(t)
+	path := filepath.Join(home, ".claude", "projects", "-work", testSessionID+".jsonl")
+	writeRows(t, path,
+		map[string]any{"type": "user", "uuid": "u1", "timestamp": "2026-08-12T10:00:00Z",
+			"message": map[string]any{"content": []any{
+				map[string]any{"type": "text", "text": "please refactor the parser"},
+				map[string]any{"type": "text", "text": "<system-reminder>INJECTED-SECRET</system-reminder>"},
+			}}},
+		map[string]any{"type": "assistant", "uuid": "a1", "timestamp": "2026-08-12T10:00:01Z",
+			"message": map[string]any{"content": []any{map[string]any{"type": "text", "text": "done"}}}},
+	)
+
+	page, err := reader.Read("claude", testSessionID, "", 80)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if page.Total != 2 {
+		t.Fatalf("entries = %#v, want the prompt and the answer", page.Entries)
+	}
+	if got := page.Entries[0].Text; got != "please refactor the parser" {
+		t.Errorf("user text = %q, want the prompt block only", got)
+	}
+	for _, entry := range page.Entries {
+		if strings.Contains(entry.Text, "INJECTED-SECRET") {
+			t.Fatalf("injected system-reminder block reached the conversation view: %q", entry.Text)
+		}
+	}
+}
+
+// An envelope in the FIRST block must still suppress that block while later
+// real prompt text survives, proving the filter is per block in both directions
+// rather than an all-or-nothing check on the record.
+func TestClaudeConversationKeepsPromptWhenEnvelopeComesFirst(t *testing.T) {
+	reader, home := testReader(t)
+	path := filepath.Join(home, ".claude", "projects", "-work", testSessionID+".jsonl")
+	writeRows(t, path,
+		map[string]any{"type": "user", "uuid": "u1", "timestamp": "2026-08-12T10:00:00Z",
+			"message": map[string]any{"content": []any{
+				map[string]any{"type": "text", "text": "<system-reminder>INJECTED-SECRET</system-reminder>"},
+				map[string]any{"type": "text", "text": "the actual question"},
+			}}},
+	)
+
+	page, err := reader.Read("claude", testSessionID, "", 80)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if page.Total != 1 || page.Entries[0].Text != "the actual question" {
+		t.Fatalf("entries = %#v, want only the real prompt text", page.Entries)
+	}
+}


### PR DESCRIPTION
Claude transcripts store a user turn's `content` either as a plain string or as an array
of blocks. The reader only handled the string shape, so every array-shaped user turn was dropped:
the phone showed the assistant's replies with no visible prompt above them, and a conversation whose
prompts are all array-shaped rendered as zero visible turns.

Keep the array shape, taking the text blocks and ignoring the rest, and treat the tool/envelope
blocks the same way the string path already does.

### Verification

`go test -count=1 ./internal/conversation/...` on top of `main`. The five new tests are load-bearing,
not decorative: with `reader.go` reverted to `main`'s version and only the tests applied, all five fail
(`TestClaudeConversationKeepsArrayShapedUserPrompts` reports `Total:0, want one visible turn`);
restoring `reader.go` makes them pass.

Covered shapes: plain string, array with a text block, array with only `tool_result` blocks, array with
only thinking blocks, empty array, `null` content, envelope-first and envelope-after-first ordering,
and array-shaped slash commands.

`gofmt -l internal` empty, `go vet ./...` clean. No dependency changes.

### Scope

`internal/conversation/reader.go` (+27/-3) and its test (+216). Independent of my other two PRs;
touches no file they touch.

---

**Interaction with #18:** this PR and #18 both append test functions at the end of
`internal/conversation/reader_test.go`, so whichever lands second needs a trivial rebase — the
resolution is the union of both sides, no judgement call. I verified that merging the two produces a
tree identical to my local integration branch and that all four affected packages stay green.