### PR TITLE
feat: resolve agent transcript and session roots through one profile-aware seam

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,3 +38,11 @@ WEB_PROJECT=herdr-mobile-relay
 #   HERDR_TRANSPORT_FORCE_RELAY=0   Test flag: 1 disables the direct WebRTC
 #                                   upgrade and keeps every frame on the gateway
 #                                   path. Default 0.
+#   HERDR_CLAUDE_CONFIG_DIRS=       Extra Claude Code config dirs, colon-
+#                                   separated, added to the ~/.claude default. See
+#                                   README.md: "Agents with a non-default config
+#                                   directory".
+#   HERDR_QODER_CONFIG_DIRS=        Same, for Qoder CLI; added to ~/.qoder.
+#   HERDR_CODEX_CONFIG_DIRS=        Same, for Codex; added to ~/.codex.
+#   HERDR_PI_CONFIG_DIRS=           Same, for Pi; added to ~/.pi/agent.
+#   HERDR_OMP_CONFIG_DIRS=          Same, for Oh My Pi; added to ~/.omp/agent.

--- a/README.md
+++ b/README.md
@@ -92,6 +92,53 @@ fallback; Cloudflare tunnel traffic stays on Cloudflare.
 - **[Permanent Cloudflare tunnel →](docs/cloudflare-tunnel.md)**
 - **[Run your own gateway →](docs/gateway-self-hosting.md)**
 
+## Agents with a non-default config directory
+
+The relay runs as a background launchd/systemd user service, so it never
+inherits the shell environment a Herdr pane runs in. If a pane sets
+`CLAUDE_CONFIG_DIR`, `PI_CODING_AGENT_DIR`, or similar to use a non-default
+profile — one per herdr setup — the pane title still resolves correctly, but
+the relay looks for the conversation transcript in the wrong directory, and
+the conversation view shows "No conversation log is available for this
+session."
+
+Tell the relay about every profile you use with one of these:
+
+| Variable | Home default it adds to | Agent's own directory variable |
+| --- | --- | --- |
+| `HERDR_CLAUDE_CONFIG_DIRS` | `~/.claude` | `CLAUDE_CONFIG_DIR` |
+| `HERDR_QODER_CONFIG_DIRS` | `~/.qoder` | none |
+| `HERDR_CODEX_CONFIG_DIRS` | `~/.codex` | `CODEX_HOME` |
+| `HERDR_PI_CONFIG_DIRS` | `~/.pi/agent` | `PI_CODING_AGENT_DIR` |
+| `HERDR_OMP_CONFIG_DIRS` | `~/.omp/agent` | `PI_CODING_AGENT_DIR` (Oh My Pi is a Pi fork and shares Pi's default) |
+
+Two things to get right:
+
+- The home default is always searched. Setting a list *adds* profiles; it
+  never replaces the default.
+- Entries are config directories — the same value you'd put in
+  `CLAUDE_CONFIG_DIR` — not pre-joined `projects`/`sessions` paths. The relay
+  appends the right leaf itself.
+
+Separate multiple entries with your platform's path-list separator (`:` on
+Unix, `;` on Windows), same as `PATH`.
+
+Set these in the file named by `HERDR_RELAY_ENV`: `$HERDR_PLUGIN_CONFIG_DIR/relay.env`
+for an installation, `relay/.env` for a checkout. For example, with two herdr
+setups using `~/agents/claude-work` and `~/agents/claude-personal` as their
+Claude profiles, add:
+
+```bash
+HERDR_CLAUDE_CONFIG_DIRS=~/agents/claude-work:~/agents/claude-personal
+```
+
+The service wrapper sources that file with `set -a`, so every key in it
+becomes part of the relay's environment — quote a path that contains spaces,
+since the file is parsed by bash. After editing, restart the relay: reopen
+the setup menu with the `herdr plugin pane open` command under **Get started
+in two minutes** above, then choose your connection option again. An
+already-installed background service is restarted rather than started twice.
+
 ## Documentation
 
 | Page | What is in it |

--- a/README.md
+++ b/README.md
@@ -102,7 +102,11 @@ the relay looks for the conversation transcript in the wrong directory, and
 the conversation view shows "No conversation log is available for this
 session."
 
-Tell the relay about every profile you use with one of these:
+Pi and Oh My Pi need no configuration for their named profiles: both keep a
+profile's sessions at `<config root>/profiles/<name>/agent`, so the relay
+discovers `~/.omp/profiles/*/agent` and `~/.pi/profiles/*/agent` on startup.
+Restart the relay after adding a profile. Every other case — and a Pi or Oh My
+Pi config root moved somewhere else — needs to be named explicitly:
 
 | Variable | Home default it adds to | Agent's own directory variable |
 | --- | --- | --- |
@@ -112,13 +116,15 @@ Tell the relay about every profile you use with one of these:
 | `HERDR_PI_CONFIG_DIRS` | `~/.pi/agent` | `PI_CODING_AGENT_DIR` |
 | `HERDR_OMP_CONFIG_DIRS` | `~/.omp/agent` | `PI_CODING_AGENT_DIR` (Oh My Pi is a Pi fork and shares Pi's default) |
 
-Two things to get right:
+Three things to get right:
 
 - The home default is always searched. Setting a list *adds* profiles; it
   never replaces the default.
 - Entries are config directories — the same value you'd put in
   `CLAUDE_CONFIG_DIR` — not pre-joined `projects`/`sessions` paths. The relay
   appends the right leaf itself.
+- What you configure is searched before what the relay discovered, and the home
+  default is searched last.
 
 Separate multiple entries with your platform's path-list separator (`:` on
 Unix, `;` on Windows), same as `PATH`.

--- a/internal/agentroots/agentroots.go
+++ b/internal/agentroots/agentroots.go
@@ -1,0 +1,101 @@
+// Package agentroots resolves the directories the relay searches for a coding
+// agent's transcript and session files.
+//
+// The relay runs as a launchd/systemd user service, so it does not inherit the
+// shell environment herdr uses when it spawns an agent pane. When an agent is
+// configured with a non-default config directory - one profile per herdr setup -
+// that per-pane value is invisible to the relay by construction.
+//
+// Every agent therefore resolves to a *list* of roots rather than a single one.
+// Order is: the relay's own platform path list (HERDR_<AGENT>_CONFIG_DIRS), the
+// agent's own single-directory variable, then the home default. The home default
+// is always appended, so configuring the list adds profiles instead of replacing
+// the default profile.
+//
+// Both the conversation reader and the session-title resolver resolve through
+// this package, which is what keeps a pane's title and its transcript from
+// being looked up in different trees.
+package agentroots
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Relay-side overrides. Each holds a platform-separated list (":" on Unix, ";"
+// on Windows, as in PATH) of *config directories* - the same values that would
+// go in CLAUDE_CONFIG_DIR and friends - not pre-joined transcript roots. The
+// service wrapper exports every key of relay.env into the relay process, so
+// these belong in that file.
+const (
+	ClaudeListEnv = "HERDR_CLAUDE_CONFIG_DIRS"
+	QoderListEnv  = "HERDR_QODER_CONFIG_DIRS"
+	CodexListEnv  = "HERDR_CODEX_CONFIG_DIRS"
+	PiListEnv     = "HERDR_PI_CONFIG_DIRS"
+	OMPListEnv    = "HERDR_OMP_CONFIG_DIRS"
+)
+
+// Claude reports the transcript roots for Claude Code, honouring
+// CLAUDE_CONFIG_DIR exactly as it did when a single root was resolved.
+func Claude(home string) []string {
+	return resolve(ClaudeListEnv, "CLAUDE_CONFIG_DIR", filepath.Join(home, ".claude"), "projects")
+}
+
+// Qoder reports the transcript roots for Qoder CLI, which has no config
+// directory variable of its own.
+func Qoder(home string) []string {
+	return resolve(QoderListEnv, "", filepath.Join(home, ".qoder"), "projects")
+}
+
+// Codex reports the rollout roots for OpenAI Codex.
+func Codex(home string) []string {
+	return resolve(CodexListEnv, "CODEX_HOME", filepath.Join(home, ".codex"), "sessions")
+}
+
+// CodexHomes reports the Codex config directories themselves, for consumers
+// that read a file stored beside the sessions tree (session_index.jsonl).
+func CodexHomes(home string) []string {
+	return resolve(CodexListEnv, "CODEX_HOME", filepath.Join(home, ".codex"), "")
+}
+
+// Pi reports the session roots for the Pi coding agent.
+func Pi(home string) []string {
+	return resolve(PiListEnv, "PI_CODING_AGENT_DIR", filepath.Join(home, ".pi", "agent"), "sessions")
+}
+
+// OMP reports the session roots for Oh My Pi. Oh My Pi is a Pi fork and reads
+// the same PI_CODING_AGENT_DIR override for its default profile; named profiles
+// ignore that variable and live under <config root>/profiles/<name>/agent,
+// which is what HERDR_OMP_CONFIG_DIRS is for.
+func OMP(home string) []string {
+	return resolve(OMPListEnv, "PI_CODING_AGENT_DIR", filepath.Join(home, ".omp", "agent"), "sessions")
+}
+
+// resolve builds the ordered, de-duplicated root list for one agent. singleEnv
+// may be empty for agents without a config directory variable. leaf may be
+// empty to report the config directories themselves.
+func resolve(listEnv, singleEnv, homeBase, leaf string) []string {
+	seen := make(map[string]bool, 4)
+	roots := make([]string, 0, 4)
+	add := func(base string) {
+		base = strings.TrimSpace(base)
+		if base == "" {
+			return
+		}
+		root := filepath.Join(base, leaf)
+		if seen[root] {
+			return
+		}
+		seen[root] = true
+		roots = append(roots, root)
+	}
+	for _, base := range filepath.SplitList(os.Getenv(listEnv)) {
+		add(base)
+	}
+	if singleEnv != "" {
+		add(os.Getenv(singleEnv))
+	}
+	add(homeBase)
+	return roots
+}

--- a/internal/agentroots/agentroots.go
+++ b/internal/agentroots/agentroots.go
@@ -8,9 +8,10 @@
 //
 // Every agent therefore resolves to a *list* of roots rather than a single one.
 // Order is: the relay's own platform path list (HERDR_<AGENT>_CONFIG_DIRS), the
-// agent's own single-directory variable, then the home default. The home default
-// is always appended, so configuring the list adds profiles instead of replacing
-// the default profile.
+// agent's own single-directory variable, then any profile directories discovered
+// on disk (Pi and Oh My Pi only), then the home default. The home default is
+// always appended, so configuring the list adds profiles instead of replacing
+// the default profile, and configuration always outranks discovery.
 //
 // Both the conversation reader and the session-title resolver resolve through
 // this package, which is what keeps a pane's title and its transcript from
@@ -59,25 +60,91 @@ func CodexHomes(home string) []string {
 	return resolve(CodexListEnv, "CODEX_HOME", filepath.Join(home, ".codex"), "")
 }
 
-// Pi reports the session roots for the Pi coding agent.
+// Pi reports the session roots for the Pi coding agent, including the agent
+// directory of every named profile found under its config root.
 func Pi(home string) []string {
-	return resolve(PiListEnv, "PI_CODING_AGENT_DIR", filepath.Join(home, ".pi", "agent"), "sessions")
+	configRoot := filepath.Join(home, ".pi")
+	return resolve(PiListEnv, "PI_CODING_AGENT_DIR", filepath.Join(configRoot, "agent"), "sessions",
+		profileAgentDirs(configRoot)...)
 }
 
-// OMP reports the session roots for Oh My Pi. Oh My Pi is a Pi fork and reads
-// the same PI_CODING_AGENT_DIR override for its default profile; named profiles
-// ignore that variable and live under <config root>/profiles/<name>/agent,
-// which is what HERDR_OMP_CONFIG_DIRS is for.
+// OMP reports the session roots for Oh My Pi, including the agent directory of
+// every named profile found under its config root.
+//
+// Oh My Pi is a Pi fork and reads the same PI_CODING_AGENT_DIR override, but
+// only while no profile is active: verified against the omp 18.0.3 bundle, where
+// `agentDirOverride` is passed as `t ? undefined : e.agentDirOverride` and `t` is
+// the resolved profile. There is no OMP_AGENT_DIR, OMP_CODING_AGENT_DIR or
+// OMP_CONFIG_DIR - none of those strings occur in the binary at all.
+//
+// Note the asymmetry, because it is easy to misread the above as "a profile has
+// nothing to do with this variable": omp *ignores* PI_CODING_AGENT_DIR as an
+// input under a profile, but it *exports* the resolved agent directory back into
+// the environment of what it spawns, so a pane running a profile does carry a
+// PI_CODING_AGENT_DIR pointing at that profile. That is of no use here - the
+// relay cannot read a pane's environment, which is the whole reason this package
+// exists - but it is why discovery, not the variable, is what finds profiles.
 func OMP(home string) []string {
-	return resolve(OMPListEnv, "PI_CODING_AGENT_DIR", filepath.Join(home, ".omp", "agent"), "sessions")
+	configRoot := filepath.Join(home, ".omp")
+	return resolve(OMPListEnv, "PI_CODING_AGENT_DIR", filepath.Join(configRoot, "agent"), "sessions",
+		profileAgentDirs(configRoot)...)
+}
+
+// profileAgentDirs reports the agent directory of every named profile under a
+// config root. Pi and Oh My Pi place one at <config root>/profiles/<name>/agent
+// - verified against the omp bundle, which builds exactly
+// `join(configRoot, "profiles", name, "agent")` - and a profile makes the agent
+// ignore PI_CODING_AGENT_DIR, so a profile's sessions are reachable no other
+// way. Discovering them is what lets the common one-profile-per-herdr-setup
+// layout work with no configuration at all.
+//
+// Only the home default's config root is expanded. An explicitly configured
+// entry is itself an agent directory, so treating its parent as a config root
+// would be wrong. A relocated config root - omp resolves that through
+// PI_CONFIG_DIR and XDG probing - is what the HERDR_*_CONFIG_DIRS lists are
+// for; mirroring that resolution here would couple the relay to omp's
+// internals and drift out of step with them.
+//
+// os.ReadDir sorts its result, so the discovered order is deterministic.
+//
+// Entries are classified with os.Stat, not DirEntry.IsDir. DirEntry reports the
+// directory entry's own type bits, which are ModeSymlink for a symlink, so
+// IsDir() is false for a symlink to a directory and a profile reached through
+// one would be silently skipped. omp joins the path and follows it, so the
+// relay has to as well; symlinked profile directories are a normal way to keep
+// agent configuration on another volume or in a dotfiles repo.
+func profileAgentDirs(configRoot string) []string {
+	// A relative config root would make this scan directories under the relay's
+	// working directory, which is never what the caller means. This happens only
+	// when os.UserHomeDir() failed and home is empty.
+	if !filepath.IsAbs(configRoot) {
+		return nil
+	}
+	profiles := filepath.Join(configRoot, "profiles")
+	entries, err := os.ReadDir(profiles)
+	if err != nil {
+		return nil
+	}
+	dirs := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		candidate := filepath.Join(profiles, entry.Name())
+		info, err := os.Stat(candidate)
+		if err != nil || !info.IsDir() {
+			continue
+		}
+		dirs = append(dirs, filepath.Join(candidate, "agent"))
+	}
+	return dirs
 }
 
 // resolve builds the ordered, de-duplicated root list for one agent. singleEnv
 // may be empty for agents without a config directory variable. leaf may be
-// empty to report the config directories themselves.
-func resolve(listEnv, singleEnv, homeBase, leaf string) []string {
-	seen := make(map[string]bool, 4)
-	roots := make([]string, 0, 4)
+// empty to report the config directories themselves. discovered bases are
+// appended after the environment ones and before the home default, so
+// configuration always wins over discovery and the home default stays last.
+func resolve(listEnv, singleEnv, homeBase, leaf string, discovered ...string) []string {
+	seen := make(map[string]bool, 4+len(discovered))
+	roots := make([]string, 0, 4+len(discovered))
 	add := func(base string) {
 		base = strings.TrimSpace(base)
 		if base == "" {
@@ -95,6 +162,9 @@ func resolve(listEnv, singleEnv, homeBase, leaf string) []string {
 	}
 	if singleEnv != "" {
 		add(os.Getenv(singleEnv))
+	}
+	for _, base := range discovered {
+		add(base)
 	}
 	add(homeBase)
 	return roots

--- a/internal/agentroots/agentroots_test.go
+++ b/internal/agentroots/agentroots_test.go
@@ -229,3 +229,261 @@ func TestOMPAndPiRoots(t *testing.T) {
 		}
 	})
 }
+
+// A named profile makes Oh My Pi ignore PI_CODING_AGENT_DIR entirely, so a
+// profile's sessions are reachable no other way than by knowing the layout.
+// Discovering <config root>/profiles/<name>/agent is what makes the common
+// one-profile-per-herdr-setup case work with no configuration at all.
+func TestOMPDiscoversNamedProfileAgentDirs(t *testing.T) {
+	clearAllEnv(t)
+	home := t.TempDir()
+	for _, name := range []string{"personal", "work"} {
+		if err := os.MkdirAll(filepath.Join(home, ".omp", "profiles", name, "agent", "sessions"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// A stray file under profiles/ must not become a root.
+	if err := os.WriteFile(filepath.Join(home, ".omp", "profiles", "notes.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := OMP(home)
+	want := []string{
+		filepath.Join(home, ".omp", "profiles", "personal", "agent", "sessions"),
+		filepath.Join(home, ".omp", "profiles", "work", "agent", "sessions"),
+		filepath.Join(home, ".omp", "agent", "sessions"),
+	}
+	if !slices.Equal(got, want) {
+		t.Fatalf("OMP(home) = %v, want discovered profiles then the home default %v", got, want)
+	}
+}
+
+// Discovery must not disturb configuration precedence: an explicitly configured
+// directory still comes first, and the home default still comes last.
+func TestOMPConfigurationOutranksDiscoveredProfiles(t *testing.T) {
+	clearAllEnv(t)
+	home := t.TempDir()
+	explicit := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(home, ".omp", "profiles", "personal", "agent"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(OMPListEnv, explicit)
+
+	got := OMP(home)
+	want := []string{
+		filepath.Join(explicit, "sessions"),
+		filepath.Join(home, ".omp", "profiles", "personal", "agent", "sessions"),
+		filepath.Join(home, ".omp", "agent", "sessions"),
+	}
+	if !slices.Equal(got, want) {
+		t.Fatalf("OMP(home) = %v, want %v", got, want)
+	}
+}
+
+// Discovery is additive: with no profiles directory the result is exactly what
+// it was before discovery existed, so a default install is unaffected.
+func TestDiscoveryIsANoOpWithoutProfiles(t *testing.T) {
+	clearAllEnv(t)
+	home := t.TempDir()
+	for _, c := range []struct {
+		name string
+		got  []string
+		want []string
+	}{
+		{"OMP", OMP(home), []string{filepath.Join(home, ".omp", "agent", "sessions")}},
+		{"Pi", Pi(home), []string{filepath.Join(home, ".pi", "agent", "sessions")}},
+	} {
+		if !slices.Equal(c.got, c.want) {
+			t.Errorf("%s(home) = %v, want %v", c.name, c.got, c.want)
+		}
+	}
+}
+
+// An explicitly configured entry is an agent directory, not a config root, so
+// its sibling profiles/ must never be expanded.
+func TestDiscoveryDoesNotExpandConfiguredEntries(t *testing.T) {
+	clearAllEnv(t)
+	home := t.TempDir()
+	explicit := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(explicit, "profiles", "sneaky", "agent"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(OMPListEnv, filepath.Join(explicit, "agent"))
+
+	roots := OMP(home)
+	for _, root := range roots {
+		if strings.Contains(root, "sneaky") {
+			t.Fatalf("expanded a configured entry's profiles/: %v", roots)
+		}
+	}
+}
+
+// Pi gets the same treatment as OMP, under its own config root, and the two
+// must not bleed into each other.
+func TestPiDiscoversNamedProfileAgentDirs(t *testing.T) {
+	clearAllEnv(t)
+	home := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(home, ".pi", "profiles", "alt", "agent"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	got := Pi(home)
+	want := []string{
+		filepath.Join(home, ".pi", "profiles", "alt", "agent", "sessions"),
+		filepath.Join(home, ".pi", "agent", "sessions"),
+	}
+	if !slices.Equal(got, want) {
+		t.Fatalf("Pi(home) = %v, want %v", got, want)
+	}
+	for _, root := range OMP(home) {
+		if strings.Contains(root, ".pi") {
+			t.Fatalf("OMP root list contains a Pi path: %v", OMP(home))
+		}
+	}
+}
+
+// The seam classifies profile entries with os.Stat, not DirEntry.IsDir, because
+// DirEntry reports the entry's own type bits (ModeSymlink for a symlink), so a
+// profile reached through a symlink used to be silently skipped even though omp
+// itself joins and follows that path. The discovered root uses the lexical path
+// through the symlink - containment resolution happens later, not here.
+func TestOMPDiscoversProfileReachedThroughASymlink(t *testing.T) {
+	clearAllEnv(t)
+	home := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(home, ".omp", "profiles", "personal", "agent"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	target := t.TempDir()
+	link := filepath.Join(home, ".omp", "profiles", "linked")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+
+	got := OMP(home)
+	want := []string{
+		// "linked" sorts before "personal" in os.ReadDir's order.
+		filepath.Join(home, ".omp", "profiles", "linked", "agent", "sessions"),
+		filepath.Join(home, ".omp", "profiles", "personal", "agent", "sessions"),
+		filepath.Join(home, ".omp", "agent", "sessions"),
+	}
+	if !slices.Equal(got, want) {
+		t.Fatalf("OMP(home) = %v, want the symlinked profile (lexical path, unresolved) and the real "+
+			"profile in os.ReadDir order, then the home default: %v", got, want)
+	}
+}
+
+// A dangling symlink or a plain file directly under profiles/ must not become
+// a root: os.Stat on a dangling symlink errors, and a regular file is not a
+// directory either way.
+func TestDiscoverySkipsBrokenSymlinksAndFiles(t *testing.T) {
+	clearAllEnv(t)
+	home := t.TempDir()
+	profiles := filepath.Join(home, ".omp", "profiles")
+	if err := os.MkdirAll(profiles, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(filepath.Join(home, "nowhere"), filepath.Join(profiles, "broken")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(profiles, "afile.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := OMP(home)
+	want := []string{filepath.Join(home, ".omp", "agent", "sessions")}
+	if !slices.Equal(got, want) {
+		t.Fatalf("OMP(home) = %v, want exactly the home default (broken symlink and file must be skipped): %v", got, want)
+	}
+}
+
+// profileAgentDirs returns nil for a non-absolute config root, which happens
+// only when os.UserHomeDir() failed and home is "". Without that guard, a
+// relative root would scan under the relay's working directory instead. The
+// working directory here deliberately contains a profiles/ layout that a
+// relative scan would find, so the assertion is non-vacuous.
+func TestDiscoveryIgnoresRelativeConfigRoot(t *testing.T) {
+	clearAllEnv(t)
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, ".omp", "profiles", "x", "agent"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, ".pi", "profiles", "y", "agent"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(dir)
+
+	for _, c := range []struct {
+		name string
+		got  []string
+	}{
+		{"OMP", OMP("")},
+		{"Pi", Pi("")},
+	} {
+		for _, root := range c.got {
+			if strings.Contains(root, "profiles") {
+				t.Fatalf("%s(\"\") = %v, want no profiles/ path from a relative config root", c.name, c.got)
+			}
+		}
+	}
+}
+
+// A discovered profile whose agent directory is also named explicitly in
+// HERDR_OMP_CONFIG_DIRS must not appear twice: resolve's de-duplication keys
+// on the final joined root, and the configured occurrence - added first -
+// must be the one that wins the position.
+func TestDiscoveredProfileDedupesAgainstAnIdenticalConfiguredEntry(t *testing.T) {
+	clearAllEnv(t)
+	home := t.TempDir()
+	profileAgent := filepath.Join(home, ".omp", "profiles", "personal", "agent")
+	if err := os.MkdirAll(profileAgent, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(OMPListEnv, profileAgent)
+
+	got := OMP(home)
+	root := filepath.Join(profileAgent, "sessions")
+	count := 0
+	for _, r := range got {
+		if r == root {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("OMP(home) = %v contains %d occurrences of %q, want exactly 1", got, count, root)
+	}
+	if len(got) == 0 || got[0] != root {
+		t.Fatalf("OMP(home) = %v, want the configured entry %q first", got, root)
+	}
+	want := []string{root, filepath.Join(home, ".omp", "agent", "sessions")}
+	if !slices.Equal(got, want) {
+		t.Fatalf("OMP(home) = %v, want %v", got, want)
+	}
+}
+
+// A profiles/ directory that cannot be read (permissions, not absence) must
+// degrade to the home default rather than panicking or propagating an error.
+func TestDiscoveryUnreadableProfilesDirIsANoOp(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root: chmod 0o000 does not block directory reads for root")
+	}
+	clearAllEnv(t)
+	home := t.TempDir()
+	profiles := filepath.Join(home, ".omp", "profiles")
+	if err := os.MkdirAll(profiles, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(profiles, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chmod(profiles, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	got := OMP(home)
+	want := []string{filepath.Join(home, ".omp", "agent", "sessions")}
+	if !slices.Equal(got, want) {
+		t.Fatalf("OMP(home) = %v, want exactly the home default when profiles/ is unreadable: %v", got, want)
+	}
+}

--- a/internal/agentroots/agentroots_test.go
+++ b/internal/agentroots/agentroots_test.go
@@ -1,0 +1,231 @@
+package agentroots
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+)
+
+// clearAllEnv resets every environment variable agentroots reads, so a
+// developer's shell exports (or a previous subtest) cannot leak into the
+// next scenario.
+func clearAllEnv(t *testing.T) {
+	t.Helper()
+	for _, name := range []string{
+		"CLAUDE_CONFIG_DIR", "CODEX_HOME", "PI_CODING_AGENT_DIR",
+		ClaudeListEnv, QoderListEnv, CodexListEnv, PiListEnv, OMPListEnv,
+	} {
+		t.Setenv(name, "")
+	}
+}
+
+func TestClaudeRoots(t *testing.T) {
+	t.Run("home default only", func(t *testing.T) {
+		clearAllEnv(t)
+		home := t.TempDir()
+		want := []string{filepath.Join(home, ".claude", "projects")}
+		if got := Claude(home); !slices.Equal(got, want) {
+			t.Fatalf("Claude(%q) = %v, want %v", home, got, want)
+		}
+	})
+
+	t.Run("single env var still honoured", func(t *testing.T) {
+		clearAllEnv(t)
+		home := t.TempDir()
+		t.Setenv("CLAUDE_CONFIG_DIR", "/a")
+		want := []string{
+			filepath.Join("/a", "projects"),
+			filepath.Join(home, ".claude", "projects"),
+		}
+		if got := Claude(home); !slices.Equal(got, want) {
+			t.Fatalf("Claude(%q) = %v, want %v", home, got, want)
+		}
+	})
+
+	t.Run("list env adds and comes first", func(t *testing.T) {
+		clearAllEnv(t)
+		home := t.TempDir()
+		t.Setenv(ClaudeListEnv, "/x")
+		t.Setenv("CLAUDE_CONFIG_DIR", "/a")
+		want := []string{
+			filepath.Join("/x", "projects"),
+			filepath.Join("/a", "projects"),
+			filepath.Join(home, ".claude", "projects"),
+		}
+		if got := Claude(home); !slices.Equal(got, want) {
+			t.Fatalf("Claude(%q) = %v, want %v", home, got, want)
+		}
+	})
+
+	t.Run("multi entry list keeps order", func(t *testing.T) {
+		clearAllEnv(t)
+		home := t.TempDir()
+		t.Setenv(ClaudeListEnv, strings.Join([]string{"/x", "/y"}, string(os.PathListSeparator)))
+		want := []string{
+			filepath.Join("/x", "projects"),
+			filepath.Join("/y", "projects"),
+			filepath.Join(home, ".claude", "projects"),
+		}
+		if got := Claude(home); !slices.Equal(got, want) {
+			t.Fatalf("Claude(%q) = %v, want %v", home, got, want)
+		}
+	})
+
+	t.Run("de-duplication of list entry against single var", func(t *testing.T) {
+		clearAllEnv(t)
+		home := t.TempDir()
+		t.Setenv(ClaudeListEnv, "/a")
+		t.Setenv("CLAUDE_CONFIG_DIR", "/a")
+		want := []string{
+			filepath.Join("/a", "projects"),
+			filepath.Join(home, ".claude", "projects"),
+		}
+		if got := Claude(home); !slices.Equal(got, want) {
+			t.Fatalf("Claude(%q) = %v, want %v", home, got, want)
+		}
+	})
+
+	t.Run("de-duplication of list entry against home base", func(t *testing.T) {
+		clearAllEnv(t)
+		home := t.TempDir()
+		t.Setenv(ClaudeListEnv, filepath.Join(home, ".claude"))
+		want := []string{filepath.Join(home, ".claude", "projects")}
+		if got := Claude(home); !slices.Equal(got, want) {
+			t.Fatalf("Claude(%q) = %v, want %v", home, got, want)
+		}
+	})
+
+	t.Run("blank and whitespace-only entries are skipped", func(t *testing.T) {
+		clearAllEnv(t)
+		home := t.TempDir()
+		t.Setenv(ClaudeListEnv, strings.Join([]string{"/x", "", "  ", "/y"}, string(os.PathListSeparator)))
+		want := []string{
+			filepath.Join("/x", "projects"),
+			filepath.Join("/y", "projects"),
+			filepath.Join(home, ".claude", "projects"),
+		}
+		if got := Claude(home); !slices.Equal(got, want) {
+			t.Fatalf("Claude(%q) = %v, want %v", home, got, want)
+		}
+	})
+}
+
+func TestQoderRoots(t *testing.T) {
+	t.Run("no single var override", func(t *testing.T) {
+		clearAllEnv(t)
+		home := t.TempDir()
+		t.Setenv("CLAUDE_CONFIG_DIR", "/should-not-affect-qoder")
+		t.Setenv("CODEX_HOME", "/also-should-not-affect-qoder")
+		t.Setenv("PI_CODING_AGENT_DIR", "/nor-this")
+		want := []string{filepath.Join(home, ".qoder", "projects")}
+		if got := Qoder(home); !slices.Equal(got, want) {
+			t.Fatalf("Qoder(%q) = %v, want %v (single-dir env vars must not affect Qoder)", home, got, want)
+		}
+	})
+
+	t.Run("home default and list env", func(t *testing.T) {
+		clearAllEnv(t)
+		home := t.TempDir()
+		t.Setenv(QoderListEnv, "/q")
+		want := []string{
+			filepath.Join("/q", "projects"),
+			filepath.Join(home, ".qoder", "projects"),
+		}
+		if got := Qoder(home); !slices.Equal(got, want) {
+			t.Fatalf("Qoder(%q) = %v, want %v", home, got, want)
+		}
+	})
+}
+
+func TestCodexRootsAndHomes(t *testing.T) {
+	scenarios := []struct {
+		name  string
+		setup func(t *testing.T)
+	}{
+		{name: "default only", setup: func(t *testing.T) {}},
+		{name: "CODEX_HOME override", setup: func(t *testing.T) {
+			t.Setenv("CODEX_HOME", "/c")
+		}},
+		{name: "list env adds and comes first", setup: func(t *testing.T) {
+			t.Setenv(CodexListEnv, "/c1")
+			t.Setenv("CODEX_HOME", "/c2")
+		}},
+	}
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+			clearAllEnv(t)
+			home := t.TempDir()
+			scenario.setup(t)
+
+			sessions := Codex(home)
+			homes := CodexHomes(home)
+			if len(sessions) != len(homes) {
+				t.Fatalf("len(Codex(home)) = %d, len(CodexHomes(home)) = %d, want equal (%v vs %v)", len(sessions), len(homes), sessions, homes)
+			}
+			for index := range homes {
+				want := filepath.Join(homes[index], "sessions")
+				if sessions[index] != want {
+					t.Fatalf("Codex(home)[%d] = %q, want %q (= filepath.Join(CodexHomes(home)[%d], \"sessions\"))", index, sessions[index], want, index)
+				}
+			}
+		})
+	}
+}
+
+func TestOMPAndPiRoots(t *testing.T) {
+	t.Run("distinct home defaults", func(t *testing.T) {
+		clearAllEnv(t)
+		home := t.TempDir()
+		wantPi := []string{filepath.Join(home, ".pi", "agent", "sessions")}
+		wantOMP := []string{filepath.Join(home, ".omp", "agent", "sessions")}
+		if got := Pi(home); !slices.Equal(got, wantPi) {
+			t.Fatalf("Pi(%q) = %v, want %v", home, got, wantPi)
+		}
+		if got := OMP(home); !slices.Equal(got, wantOMP) {
+			t.Fatalf("OMP(%q) = %v, want %v", home, got, wantOMP)
+		}
+	})
+
+	t.Run("shared single var, distinct base", func(t *testing.T) {
+		clearAllEnv(t)
+		home := t.TempDir()
+		t.Setenv("PI_CODING_AGENT_DIR", "/shared")
+		wantPi := []string{
+			filepath.Join("/shared", "sessions"),
+			filepath.Join(home, ".pi", "agent", "sessions"),
+		}
+		wantOMP := []string{
+			filepath.Join("/shared", "sessions"),
+			filepath.Join(home, ".omp", "agent", "sessions"),
+		}
+		if got := Pi(home); !slices.Equal(got, wantPi) {
+			t.Fatalf("Pi(%q) = %v, want %v", home, got, wantPi)
+		}
+		if got := OMP(home); !slices.Equal(got, wantOMP) {
+			t.Fatalf("OMP(%q) = %v, want %v", home, got, wantOMP)
+		}
+	})
+
+	t.Run("independent list vars", func(t *testing.T) {
+		clearAllEnv(t)
+		home := t.TempDir()
+		t.Setenv(PiListEnv, "/pi-profile")
+		t.Setenv(OMPListEnv, "/omp-profile")
+		wantPi := []string{
+			filepath.Join("/pi-profile", "sessions"),
+			filepath.Join(home, ".pi", "agent", "sessions"),
+		}
+		wantOMP := []string{
+			filepath.Join("/omp-profile", "sessions"),
+			filepath.Join(home, ".omp", "agent", "sessions"),
+		}
+		if got := Pi(home); !slices.Equal(got, wantPi) {
+			t.Fatalf("Pi(%q) = %v, want %v (PiListEnv must not leak into OMP)", home, got, wantPi)
+		}
+		if got := OMP(home); !slices.Equal(got, wantOMP) {
+			t.Fatalf("OMP(%q) = %v, want %v (OMPListEnv must not leak into Pi)", home, got, wantOMP)
+		}
+	})
+}

--- a/internal/app/conversation_invariant_test.go
+++ b/internal/app/conversation_invariant_test.go
@@ -1,0 +1,197 @@
+package app
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/0cv/herdr-mobile-relay/internal/agentroots"
+	"github.com/0cv/herdr-mobile-relay/internal/conversation"
+	"github.com/0cv/herdr-mobile-relay/internal/session"
+)
+
+// The bug this package's conversation plumbing exists to avoid: the pane title
+// was read out of one directory tree while the transcript was looked up in
+// another, so the header showed a correct title next to "No conversation log is
+// available for this session."
+//
+// session.Resolver and conversation.Reader live in different packages and
+// neither can see the other's fields, so an assertion inside either package can
+// only restate its own construction. The invariant is a BEHAVIOURAL one and has
+// to be tested where both types meet, which is here: for the same agent, cwd and
+// session id, the title and the transcript must either both resolve or both
+// fail. Never one without the other.
+func writeClaudeTranscript(t *testing.T, path, title string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// The user prompt is a bare string, not a block array, on purpose. This file
+	// tests PATH RESOLUTION - which tree a transcript is found in - and must not
+	// depend on how Claude content shapes are parsed. A string prompt parses
+	// identically before and after the array-content fix, so these tests stay
+	// green at every commit in the series and can also be run against v0.17.5.
+	rows := []map[string]any{
+		{"type": "summary", "summary": title},
+		{"type": "user", "uuid": "u1", "timestamp": "2026-08-12T10:00:00Z",
+			"message": map[string]any{"content": "the prompt"}},
+		{"type": "assistant", "uuid": "a1", "timestamp": "2026-08-12T10:00:01Z",
+			"message": map[string]any{"content": []any{map[string]any{"type": "text", "text": "the answer"}}}},
+	}
+	var buf []byte
+	for _, row := range rows {
+		encoded, err := json.Marshal(row)
+		if err != nil {
+			t.Fatal(err)
+		}
+		buf = append(buf, encoded...)
+		buf = append(buf, '\n')
+	}
+	if err := os.WriteFile(path, buf, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func clearAgentEnv(t *testing.T) {
+	t.Helper()
+	for _, name := range []string{
+		"CLAUDE_CONFIG_DIR", "CODEX_HOME", "PI_CODING_AGENT_DIR",
+		agentroots.ClaudeListEnv, agentroots.QoderListEnv, agentroots.CodexListEnv,
+		agentroots.PiListEnv, agentroots.OMPListEnv,
+	} {
+		t.Setenv(name, "")
+	}
+}
+
+const invariantSession = "123e4567-e89b-12d3-a456-426614174321"
+
+// Both halves resolve for a session reachable only through a non-default
+// profile. Before the fix the title resolved and the transcript did not, which
+// is exactly the reported symptom.
+func TestTitleAndTranscriptAgreeForANonDefaultProfile(t *testing.T) {
+	clearAgentEnv(t)
+	home := t.TempDir()
+	profile := t.TempDir()
+	t.Setenv(agentroots.ClaudeListEnv, profile)
+
+	const cwd = "/work/app"
+	writeClaudeTranscript(t, filepath.Join(profile, "projects", "-work-app", invariantSession+".jsonl"), "Profile Title")
+
+	title := session.NewResolver(home).SessionName("claude", cwd, invariantSession)
+	page, err := conversation.NewReader(home).Read("claude", invariantSession, "", 80)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if title == "" {
+		t.Errorf("title did not resolve from the configured profile")
+	}
+	if !page.Available {
+		t.Errorf("transcript did not resolve from the configured profile: reason=%q", page.Reason)
+	}
+	if title != "" && !page.Available {
+		t.Fatalf("INVARIANT BROKEN: title %q resolved while the transcript reported %q", title, page.Reason)
+	}
+	if page.Available && page.Total != 2 {
+		t.Errorf("page total = %d, want the prompt and the answer", page.Total)
+	}
+}
+
+// The same agreement must hold for the home default with no configuration at
+// all, so the fix is a no-op for a single-profile install.
+func TestTitleAndTranscriptAgreeForTheHomeDefault(t *testing.T) {
+	clearAgentEnv(t)
+	home := t.TempDir()
+
+	const cwd = "/work/app"
+	writeClaudeTranscript(t, filepath.Join(home, ".claude", "projects", "-work-app", invariantSession+".jsonl"), "Home Title")
+
+	title := session.NewResolver(home).SessionName("claude", cwd, invariantSession)
+	page, err := conversation.NewReader(home).Read("claude", invariantSession, "", 80)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if title == "" || !page.Available {
+		t.Fatalf("INVARIANT BROKEN: title=%q available=%v reason=%q", title, page.Available, page.Reason)
+	}
+}
+
+// And they must fail TOGETHER when the session exists in no configured root,
+// with the reason string that distinguishes a path-resolution failure from a
+// missing session id. A title without a transcript here would be the original
+// bug reappearing.
+func TestTitleAndTranscriptFailTogetherWhenNoRootHasTheSession(t *testing.T) {
+	clearAgentEnv(t)
+	home := t.TempDir()
+	profile := t.TempDir()
+	t.Setenv(agentroots.ClaudeListEnv, profile)
+
+	// A project directory exists in both roots, but neither holds this session.
+	for _, root := range []string{filepath.Join(profile, "projects"), filepath.Join(home, ".claude", "projects")} {
+		if err := os.MkdirAll(filepath.Join(root, "-work-app"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	title := session.NewResolver(home).SessionName("claude", "/work/app", invariantSession)
+	page, err := conversation.NewReader(home).Read("claude", invariantSession, "", 80)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if title != "" {
+		t.Errorf("title = %q, want empty when no root holds the session", title)
+	}
+	if page.Available {
+		t.Errorf("transcript resolved from nowhere: %#v", page.Entries)
+	}
+	if page.Reason != "No conversation log is available for this session." {
+		t.Errorf("reason = %q, want the path-resolution reason verbatim", page.Reason)
+	}
+}
+
+// The exact production shape of the reported bug, written so it runs against
+// v0.17.5 too: the pane's agent used a non-default config directory, so the
+// relay's CLAUDE_CONFIG_DIR names a profile, while the transcript the title is
+// read from sits under ~/.claude. Before the fix the reader honoured
+// CLAUDE_CONFIG_DIR and searched only the profile while the resolver ignored it
+// and searched only ~/.claude, so the title resolved and the transcript did not.
+// This is the regression guard: it fails on v0.17.5 and passes here.
+func TestLegacyConfigDirDoesNotSplitTitleFromTranscript(t *testing.T) {
+	clearAgentEnv(t)
+	home := t.TempDir()
+	profile := t.TempDir()
+	t.Setenv("CLAUDE_CONFIG_DIR", profile)
+	if err := os.MkdirAll(filepath.Join(profile, "projects"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	writeClaudeTranscript(t, filepath.Join(home, ".claude", "projects", "-work-app", invariantSession+".jsonl"), "Home Title")
+
+	title := session.NewResolver(home).SessionName("claude", "/work/app", invariantSession)
+	page, err := conversation.NewReader(home).Read("claude", invariantSession, "", 80)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if title != "" && !page.Available {
+		t.Fatalf("INVARIANT BROKEN, the reported bug: title %q resolved while the transcript reported %q",
+			title, page.Reason)
+	}
+	if title == "" || !page.Available {
+		t.Fatalf("both halves should resolve: title=%q available=%v reason=%q", title, page.Available, page.Reason)
+	}
+}
+
+// A missing session id is a different failure from a path that cannot be
+// resolved, and the two reason strings are the only signal that tells an
+// operator which one happened. Pin both.
+func TestMissingSessionIDKeepsItsOwnReason(t *testing.T) {
+	clearAgentEnv(t)
+	page, err := conversation.NewReader(t.TempDir()).Read("claude", "", "", 80)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if page.Available || page.Reason != "This agent has not reported a conversation session yet." {
+		t.Fatalf("page = %#v, want the missing-session-id reason verbatim", page)
+	}
+}

--- a/internal/conversation/reader.go
+++ b/internal/conversation/reader.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"unicode/utf8"
 
+	"github.com/0cv/herdr-mobile-relay/internal/agentroots"
 	panehistory "github.com/0cv/herdr-mobile-relay/internal/history"
 )
 
@@ -62,23 +63,13 @@ type Reader struct {
 }
 
 func NewReader(home string) *Reader {
-	claudeHome := firstConfiguredRoot("CLAUDE_CONFIG_DIR", filepath.Join(home, ".claude"))
-	codexHome := firstConfiguredRoot("CODEX_HOME", filepath.Join(home, ".codex"))
-	piHome := firstConfiguredRoot("PI_CODING_AGENT_DIR", filepath.Join(home, ".pi", "agent"))
 	return &Reader{
-		claudeRoots: []string{filepath.Join(claudeHome, "projects")},
-		qoderRoots:  []string{filepath.Join(home, ".qoder", "projects")},
-		codexRoots:  []string{filepath.Join(codexHome, "sessions")},
-		piRoots:     []string{filepath.Join(piHome, "sessions")},
-		ompRoots:    []string{filepath.Join(home, ".omp", "agent", "sessions")},
+		claudeRoots: agentroots.Claude(home),
+		qoderRoots:  agentroots.Qoder(home),
+		codexRoots:  agentroots.Codex(home),
+		piRoots:     agentroots.Pi(home),
+		ompRoots:    agentroots.OMP(home),
 	}
-}
-
-func firstConfiguredRoot(environment, fallback string) string {
-	if configured := strings.TrimSpace(os.Getenv(environment)); configured != "" {
-		return configured
-	}
-	return fallback
 }
 
 func Supported(agent string) bool {

--- a/internal/conversation/reader_test.go
+++ b/internal/conversation/reader_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/0cv/herdr-mobile-relay/internal/agentroots"
 )
 
 const testSessionID = "123e4567-e89b-12d3-a456-426614174000"
@@ -15,6 +17,11 @@ func testReader(t *testing.T) (*Reader, string) {
 	t.Setenv("CLAUDE_CONFIG_DIR", "")
 	t.Setenv("CODEX_HOME", "")
 	t.Setenv("PI_CODING_AGENT_DIR", "")
+	t.Setenv(agentroots.ClaudeListEnv, "")
+	t.Setenv(agentroots.QoderListEnv, "")
+	t.Setenv(agentroots.CodexListEnv, "")
+	t.Setenv(agentroots.PiListEnv, "")
+	t.Setenv(agentroots.OMPListEnv, "")
 	home := t.TempDir()
 	return NewReader(home), home
 }
@@ -173,5 +180,103 @@ func TestClaudeConversationAssociatesToolResultsWithCallingTurn(t *testing.T) {
 		!strings.Contains(tool.Input, `"path":"README.md"`) ||
 		tool.Output != "file contents" || tool.Error {
 		t.Fatalf("tool = %#v", tool)
+	}
+}
+
+const secondSessionID = "223e4567-e89b-12d3-a456-426614174001"
+
+func TestClaudeConversationResolvesFromAdditionalConfiguredRoot(t *testing.T) {
+	_, home := testReader(t)
+	profileDir := t.TempDir()
+	t.Setenv(agentroots.ClaudeListEnv, profileDir)
+	reader := NewReader(home)
+
+	profilePath := filepath.Join(profileDir, "projects", "-work", testSessionID+".jsonl")
+	writeRows(t, profilePath,
+		map[string]any{"type": "user", "uuid": "u1", "timestamp": "2026-08-12T10:00:00Z", "message": map[string]any{"content": "from profile root"}},
+		map[string]any{"type": "assistant", "uuid": "a1", "timestamp": "2026-08-12T10:00:01Z", "message": map[string]any{"content": []any{map[string]any{"type": "text", "text": "profile answer"}}}},
+	)
+	profilePage, err := reader.Read("claude", testSessionID, "", 80)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !profilePage.Available || profilePage.Total != 2 ||
+		profilePage.Entries[0].Text != "from profile root" || profilePage.Entries[1].Text != "profile answer" {
+		t.Fatalf("profile page = %#v, want two entries resolved from the additional root", profilePage)
+	}
+
+	homePath := filepath.Join(home, ".claude", "projects", "-work2", secondSessionID+".jsonl")
+	writeRows(t, homePath,
+		map[string]any{"type": "user", "uuid": "u2", "timestamp": "2026-08-12T10:00:00Z", "message": map[string]any{"content": "from home root"}},
+	)
+	homePage, err := reader.Read("claude", secondSessionID, "", 80)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !homePage.Available || homePage.Total != 1 || homePage.Entries[0].Text != "from home root" {
+		t.Fatalf("home page = %#v, want the home-default root to still resolve alongside the configured list", homePage)
+	}
+}
+
+func TestClaudeConversationUnavailableWhenSessionMissingFromAllRoots(t *testing.T) {
+	reader, _ := testReader(t)
+	page, err := reader.Read("claude", testSessionID, "", 80)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if page.Available {
+		t.Fatalf("page = %#v, want unavailable", page)
+	}
+	if page.Reason != "No conversation log is available for this session." {
+		t.Fatalf("reason = %q", page.Reason)
+	}
+}
+
+func TestPiConversationConfinesReportedPathAcrossMultipleRoots(t *testing.T) {
+	_, home := testReader(t)
+	profileDir := t.TempDir()
+	t.Setenv(agentroots.PiListEnv, profileDir)
+	reader := NewReader(home)
+
+	external := filepath.Join(t.TempDir(), "outside.jsonl")
+	writeRows(t, external, map[string]any{"type": "message", "message": map[string]any{"role": "user", "content": "outside"}})
+
+	linkDir := filepath.Join(profileDir, "sessions", "--work--")
+	if err := os.MkdirAll(linkDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(linkDir, "linked.jsonl")
+	if err := os.Symlink(external, link); err != nil {
+		t.Fatal(err)
+	}
+
+	page, err := reader.Read("pi", link, "", 80)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if page.Available {
+		t.Fatal("symlink inside a configured root pointing outside every root was served")
+	}
+}
+
+func TestOMPConversationResolvesFromConfiguredProfileRoot(t *testing.T) {
+	_, home := testReader(t)
+	profileDir := t.TempDir()
+	t.Setenv(agentroots.OMPListEnv, profileDir)
+	reader := NewReader(home)
+
+	path := filepath.Join(profileDir, "sessions", "-work", "session_"+testSessionID+".jsonl")
+	writeRows(t, path,
+		map[string]any{"type": "message", "id": "u1", "timestamp": "2026-08-12T10:00:00Z", "message": map[string]any{"role": "user", "content": []any{map[string]any{"type": "text", "text": "question"}}}},
+		map[string]any{"type": "message", "id": "a1", "timestamp": "2026-08-12T10:00:01Z", "message": map[string]any{"role": "assistant", "content": []any{map[string]any{"type": "text", "text": "response"}}}},
+	)
+
+	page, err := reader.Read("omp", testSessionID, "", 80)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !page.Available || page.Total != 2 ||
+		page.Entries[0].Text != "question" || page.Entries[1].Text != "response" {
+		t.Fatalf("page = %#v, want the omp profile root to resolve", page)
 	}
 }

--- a/internal/session/resolver.go
+++ b/internal/session/resolver.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/0cv/herdr-mobile-relay/internal/agentroots"
 )
 
 const cacheTTL = 60 * time.Second
@@ -21,15 +23,26 @@ type cacheEntry struct {
 }
 
 type Resolver struct {
-	mu    sync.Mutex
-	cache map[string]cacheEntry
-	home  string
+	mu          sync.Mutex
+	cache       map[string]cacheEntry
+	claudeRoots []string
+	qoderRoots  []string
+	codexHomes  []string
+	piRoots     []string
+	ompRoots    []string
 }
 
+// NewResolver resolves every agent's roots once, through the same seam
+// conversation.NewReader uses, so a pane's title and its transcript can never
+// be looked up in different trees.
 func NewResolver(home string) *Resolver {
 	return &Resolver{
-		cache: make(map[string]cacheEntry),
-		home:  home,
+		cache:       make(map[string]cacheEntry),
+		claudeRoots: agentroots.Claude(home),
+		qoderRoots:  agentroots.Qoder(home),
+		codexHomes:  agentroots.CodexHomes(home),
+		piRoots:     agentroots.Pi(home),
+		ompRoots:    agentroots.OMP(home),
 	}
 }
 
@@ -68,9 +81,9 @@ func (r *Resolver) SessionName(agent, cwd, sessionID string) string {
 	case isPiSessionAgent(agentLower):
 		name = extractPiSessionTitle(sessionPath)
 	case strings.Contains(agentLower, "qoder"):
-		name = r.projectSessionTitle(filepath.Join(r.home, ".qoder", "projects"), cwd, sessionID)
+		name = r.projectSessionTitle(r.qoderRoots, cwd, sessionID)
 	case strings.Contains(agentLower, "claude"):
-		name = r.projectSessionTitle(filepath.Join(r.home, ".claude", "projects"), cwd, sessionID)
+		name = r.projectSessionTitle(r.claudeRoots, cwd, sessionID)
 	case strings.Contains(agentLower, "codex"):
 		name = r.codexSessionName(cwd, sessionID)
 	}
@@ -101,18 +114,22 @@ func isPiSessionAgent(agent string) bool {
 }
 
 func (r *Resolver) ompSessionPath(sessionID string) string {
+	return containedSessionFile(r.ompRoots, sessionID)
+}
+
+// containedSessionFile reports the resolved path of sessionID when it names a
+// regular .jsonl file inside at least one root. The predicates are the original
+// single-root check - IsAbs, .jsonl, Abs, EvalSymlinks, Rel, Mode().IsRegular()
+// - unchanged; the path-side ones are hoisted out of the loop because they do
+// not depend on the root, and every root-side bail-out becomes "try the next
+// root" so a root that fails to resolve is skipped rather than treated as a
+// match. Multi-root means contained in at least one root, never containment
+// skipped.
+func containedSessionFile(roots []string, sessionID string) string {
 	if !filepath.IsAbs(sessionID) || filepath.Ext(sessionID) != ".jsonl" {
 		return ""
 	}
-	root, err := filepath.Abs(filepath.Join(r.home, ".omp", "agent", "sessions"))
-	if err != nil {
-		return ""
-	}
 	path, err := filepath.Abs(filepath.Clean(sessionID))
-	if err != nil {
-		return ""
-	}
-	root, err = filepath.EvalSymlinks(root)
 	if err != nil {
 		return ""
 	}
@@ -120,15 +137,25 @@ func (r *Resolver) ompSessionPath(sessionID string) string {
 	if err != nil {
 		return ""
 	}
-	rel, err := filepath.Rel(root, path)
-	if err != nil || rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+	if info, err := os.Stat(path); err != nil || !info.Mode().IsRegular() {
 		return ""
 	}
-	info, err := os.Stat(path)
-	if err != nil || !info.Mode().IsRegular() {
-		return ""
+	for _, candidate := range roots {
+		root, err := filepath.Abs(candidate)
+		if err != nil {
+			continue
+		}
+		root, err = filepath.EvalSymlinks(root)
+		if err != nil {
+			continue
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil || rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			continue
+		}
+		return path
 	}
-	return path
+	return ""
 }
 
 func extractOMPSessionTitle(path string) string {
@@ -178,34 +205,7 @@ func extractOMPSessionTitle(path string) string {
 }
 
 func (r *Resolver) piSessionPath(sessionID string) string {
-	if !filepath.IsAbs(sessionID) || filepath.Ext(sessionID) != ".jsonl" {
-		return ""
-	}
-	root, err := filepath.Abs(filepath.Join(r.home, ".pi", "agent", "sessions"))
-	if err != nil {
-		return ""
-	}
-	path, err := filepath.Abs(filepath.Clean(sessionID))
-	if err != nil {
-		return ""
-	}
-	root, err = filepath.EvalSymlinks(root)
-	if err != nil {
-		return ""
-	}
-	path, err = filepath.EvalSymlinks(path)
-	if err != nil {
-		return ""
-	}
-	rel, err := filepath.Rel(root, path)
-	if err != nil || rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
-		return ""
-	}
-	info, err := os.Stat(path)
-	if err != nil || !info.Mode().IsRegular() {
-		return ""
-	}
-	return path
+	return containedSessionFile(r.piRoots, sessionID)
 }
 
 func extractPiSessionTitle(path string) string {
@@ -233,7 +233,19 @@ func extractPiSessionTitle(path string) string {
 	return name
 }
 
-func (r *Resolver) projectSessionTitle(projectsDir, cwd, sessionID string) string {
+// projectSessionTitle returns the first non-empty title across the agent's
+// roots. A root whose project directory exists but does not hold this session
+// must not end the search - the session may live in another profile.
+func (r *Resolver) projectSessionTitle(roots []string, cwd, sessionID string) string {
+	for _, projectsDir := range roots {
+		if title := r.projectTitleInRoot(projectsDir, cwd, sessionID); title != "" {
+			return title
+		}
+	}
+	return ""
+}
+
+func (r *Resolver) projectTitleInRoot(projectsDir, cwd, sessionID string) string {
 	projectDir := r.findProjectDir(projectsDir, cwd)
 	if projectDir == "" {
 		return ""
@@ -291,7 +303,15 @@ func (r *Resolver) findProjectDir(projectsDir, cwd string) string {
 }
 
 func (r *Resolver) codexSessionName(cwd, sessionID string) string {
-	indexFile := filepath.Join(r.home, ".codex", "session_index.jsonl")
+	for _, codexHome := range r.codexHomes {
+		if name := codexIndexThreadName(filepath.Join(codexHome, "session_index.jsonl"), sessionID); name != "" {
+			return name
+		}
+	}
+	return ""
+}
+
+func codexIndexThreadName(indexFile, sessionID string) string {
 	f, err := os.Open(indexFile)
 	if err != nil {
 		return ""
@@ -391,32 +411,62 @@ func (r *Resolver) sourceSignature(agent, cwd, sessionID string) string {
 	}
 
 	if strings.Contains(agentLower, "codex") {
-		return pathSignature(filepath.Join(r.home, ".codex", "session_index.jsonl"))
+		return rootsSignature(r.codexHomes, "session_index.jsonl")
 	}
-	var projectsDir string
+	var projectsRoots []string
 	switch {
 	case strings.Contains(agentLower, "qoder"):
-		projectsDir = filepath.Join(r.home, ".qoder", "projects")
+		projectsRoots = r.qoderRoots
 	case strings.Contains(agentLower, "claude"):
-		projectsDir = filepath.Join(r.home, ".claude", "projects")
+		projectsRoots = r.claudeRoots
 	default:
 		return ""
 	}
-	projectDir := r.findProjectDir(projectsDir, cwd)
-	if projectDir == "" {
-		return pathSignature(projectsDir)
-	}
-	if sessionID != "" {
-		return pathSignature(filepath.Join(projectDir, sessionID+".jsonl"))
-	}
-	entries, _ := os.ReadDir(projectDir)
-	var signatures []string
-	for _, entry := range entries {
-		if !entry.IsDir() && strings.HasSuffix(entry.Name(), ".jsonl") {
-			signatures = append(signatures, pathSignature(filepath.Join(projectDir, entry.Name())))
+	// Sign the candidate in EVERY root, never just the first root that happens
+	// to have a project directory for this cwd. projectSessionTitle keeps
+	// searching until a root yields a non-empty title, so stopping here at an
+	// earlier root would sign a file the title did not come from and pin a
+	// stale title for the whole cache TTL. With exactly one root - every
+	// default, unconfigured install - this reduces to the original signature.
+	signatures := make([]string, 0, len(projectsRoots))
+	for _, projectsDir := range projectsRoots {
+		projectDir := r.findProjectDir(projectsDir, cwd)
+		if projectDir == "" {
+			signatures = append(signatures, pathSignature(projectsDir))
+			continue
 		}
+		if sessionID != "" {
+			signatures = append(signatures, pathSignature(filepath.Join(projectDir, sessionID+".jsonl")))
+			continue
+		}
+		// With no session id the title falls back to the sole .jsonl in the
+		// directory, so the choice depends on the whole listing: a second file
+		// appearing must invalidate the cache.
+		entries, _ := os.ReadDir(projectDir)
+		listing := make([]string, 0, len(entries))
+		for _, entry := range entries {
+			if !entry.IsDir() && strings.HasSuffix(entry.Name(), ".jsonl") {
+				listing = append(listing, pathSignature(filepath.Join(projectDir, entry.Name())))
+			}
+		}
+		sort.Strings(listing)
+		signatures = append(signatures, strings.Join(listing, "|"))
 	}
-	sort.Strings(signatures)
+	return strings.Join(signatures, "|")
+}
+
+// rootsSignature signs one file per root (or the root itself when leaf is
+// empty), joined in root order. The root list is fixed when the Resolver is
+// built, so the result is deterministic.
+func rootsSignature(roots []string, leaf string) string {
+	signatures := make([]string, 0, len(roots))
+	for _, root := range roots {
+		path := root
+		if leaf != "" {
+			path = filepath.Join(root, leaf)
+		}
+		signatures = append(signatures, pathSignature(path))
+	}
 	return strings.Join(signatures, "|")
 }
 

--- a/internal/session/resolver_test.go
+++ b/internal/session/resolver_test.go
@@ -11,6 +11,31 @@ import (
 	"github.com/0cv/herdr-mobile-relay/internal/agentroots"
 )
 
+// TestMain clears every environment variable agentroots consults before any
+// test in this package runs. Without this, a developer's exported
+// CLAUDE_CONFIG_DIR / CODEX_HOME / PI_CODING_AGENT_DIR / HERDR_*_CONFIG_DIRS
+// leaks into every test's Resolver and can override the fixture data it just
+// wrote (see clearAgentRootEnv below for the per-test escape hatch used by
+// tests that need to reassert a var mid-run). A single TestMain protects every
+// test in the package, including ones added later that forget to call
+// clearAgentRootEnv themselves - the property the per-test helper alone
+// cannot guarantee.
+func TestMain(m *testing.M) {
+	for _, key := range []string{
+		agentroots.ClaudeListEnv,
+		agentroots.QoderListEnv,
+		agentroots.CodexListEnv,
+		agentroots.PiListEnv,
+		agentroots.OMPListEnv,
+		"CLAUDE_CONFIG_DIR",
+		"CODEX_HOME",
+		"PI_CODING_AGENT_DIR",
+	} {
+		os.Setenv(key, "")
+	}
+	os.Exit(m.Run())
+}
+
 func TestQoderSessionName(t *testing.T) {
 	home := t.TempDir()
 	projDir := filepath.Join(home, ".qoder", "projects", "home-user-myapp")

--- a/internal/session/resolver_test.go
+++ b/internal/session/resolver_test.go
@@ -455,3 +455,70 @@ func TestTitleCacheTracksTheRootTheTitleActuallyCameFrom(t *testing.T) {
 		t.Fatalf("second call = %q, want %q - the cache signed the wrong root", got, "Renamed Title")
 	}
 }
+
+// The two paths this change unified did not agree before it: the conversation
+// reader honoured CLAUDE_CONFIG_DIR and searched only that directory, while the
+// resolver ignored the variable and searched only ~/.claude. Neither old
+// behaviour can be reproduced byte-for-byte on both paths at once, because that
+// disagreement was the bug. What must hold instead is that the change only ever
+// WIDENS: every lookup that resolved at v0.17.5 still resolves, to the same
+// value. This test pins that for the legacy variable - the home default stays
+// searched (the old resolver behaviour) and the configured directory is now
+// searched too (the old reader behaviour), with the configured one taking
+// precedence in the order.
+func TestLegacyClaudeConfigDirWidensWithoutDroppingTheHomeDefault(t *testing.T) {
+	clearAgentRootEnv(t)
+	home := t.TempDir()
+	profile := t.TempDir()
+	t.Setenv("CLAUDE_CONFIG_DIR", profile)
+
+	writeTitleFile(t, filepath.Join(home, ".claude", "projects", "home-user-app", "sess-home.jsonl"), "Home Title")
+	writeTitleFile(t, filepath.Join(profile, "projects", "home-user-app", "sess-profile.jsonl"), "Profile Title")
+
+	r := NewResolver(home)
+	if got, want := r.claudeRoots, []string{
+		filepath.Join(profile, "projects"),
+		filepath.Join(home, ".claude", "projects"),
+	}; !slices.Equal(got, want) {
+		t.Fatalf("claudeRoots = %v, want the configured directory first then the home default %v", got, want)
+	}
+
+	// Old resolver behaviour: ~/.claude was always searched. Still true.
+	if got := r.SessionName("claude", "/home/user/app", "sess-home"); got != "Home Title" {
+		t.Errorf("home-default session title = %q, want %q - the home default must stay searched", got, "Home Title")
+	}
+	// Old reader behaviour: CLAUDE_CONFIG_DIR was honoured. Now titles honour it too.
+	if got := r.SessionName("claude", "/home/user/app", "sess-profile"); got != "Profile Title" {
+		t.Errorf("configured-directory session title = %q, want %q", got, "Profile Title")
+	}
+}
+
+// Same widening guarantee for the agents whose roots used to be hardcoded with
+// no override at all, and for Pi/OMP sharing PI_CODING_AGENT_DIR: setting the
+// legacy variable must not cost either agent its own home default.
+func TestLegacyPiCodingAgentDirKeepsBothHomeDefaults(t *testing.T) {
+	clearAgentRootEnv(t)
+	home := t.TempDir()
+	profile := t.TempDir()
+	t.Setenv("PI_CODING_AGENT_DIR", profile)
+
+	r := NewResolver(home)
+	for _, c := range []struct {
+		name string
+		got  []string
+		want []string
+	}{
+		{"piRoots", r.piRoots, []string{
+			filepath.Join(profile, "sessions"),
+			filepath.Join(home, ".pi", "agent", "sessions"),
+		}},
+		{"ompRoots", r.ompRoots, []string{
+			filepath.Join(profile, "sessions"),
+			filepath.Join(home, ".omp", "agent", "sessions"),
+		}},
+	} {
+		if !slices.Equal(c.got, c.want) {
+			t.Errorf("%s = %v, want %v", c.name, c.got, c.want)
+		}
+	}
+}

--- a/internal/session/resolver_test.go
+++ b/internal/session/resolver_test.go
@@ -4,7 +4,11 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"slices"
+	"strings"
 	"testing"
+
+	"github.com/0cv/herdr-mobile-relay/internal/agentroots"
 )
 
 func TestQoderSessionName(t *testing.T) {
@@ -221,5 +225,233 @@ func TestExactSessionIDDoesNotFallBackToOnlyOtherFile(t *testing.T) {
 	}
 	if got := NewResolver(home).SessionName("claude", "/home/user/app", "wanted"); got != "" {
 		t.Fatalf("session name = %q, want empty exact-ID miss", got)
+	}
+}
+
+// clearAgentRootEnv unsets every variable agentroots consults, so a developer's
+// exported shell environment cannot add roots to a test and make it flaky.
+func clearAgentRootEnv(t *testing.T) {
+	t.Helper()
+	for _, key := range []string{
+		agentroots.ClaudeListEnv,
+		agentroots.QoderListEnv,
+		agentroots.CodexListEnv,
+		agentroots.PiListEnv,
+		agentroots.OMPListEnv,
+		"CLAUDE_CONFIG_DIR",
+		"CODEX_HOME",
+		"PI_CODING_AGENT_DIR",
+	} {
+		t.Setenv(key, "")
+	}
+}
+
+func writeTitleFile(t *testing.T, path, title string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	data, err := json.Marshal(map[string]any{"type": "custom-title", "customTitle": title})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, append(data, '\n'), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Pins the architectural constraint whose absence produced the original bug:
+// NewResolver must take every root from the agentroots seam instead of
+// hand-rolling paths of its own. Reverting any field below to a
+// filepath.Join(r.home, ...) fails this, because the seam also carries the
+// configured list entry set up here.
+//
+// It deliberately does NOT claim to cover the title/transcript invariant.
+// Comparing this package's fields against the seam can only restate this
+// package's own construction, and conversation.Reader's roots are unexported
+// and live in another package. The behavioural half - title and transcript
+// resolving, or failing, together - is covered where both types are visible, in
+// internal/app/conversation_invariant_test.go. Keep the two in step.
+func TestResolverSourcesEveryRootFromTheSeam(t *testing.T) {
+	clearAgentRootEnv(t)
+	home := t.TempDir()
+	t.Setenv(agentroots.ClaudeListEnv, t.TempDir())
+
+	r := NewResolver(home)
+	for _, c := range []struct {
+		name string
+		got  []string
+		want []string
+	}{
+		{"claudeRoots", r.claudeRoots, agentroots.Claude(home)},
+		{"qoderRoots", r.qoderRoots, agentroots.Qoder(home)},
+		{"codexHomes", r.codexHomes, agentroots.CodexHomes(home)},
+		{"piRoots", r.piRoots, agentroots.Pi(home)},
+		{"ompRoots", r.ompRoots, agentroots.OMP(home)},
+	} {
+		if !slices.Equal(c.got, c.want) {
+			t.Errorf("%s = %v, want the seam's %v", c.name, c.got, c.want)
+		}
+	}
+}
+
+// A root whose project directory exists but does not hold this session must not
+// end the search: the session may live in another configured profile. Returning
+// "" from the first root fails this test.
+func TestClaudeTitleFromSecondRootWhenFirstRootLacksTheSession(t *testing.T) {
+	clearAgentRootEnv(t)
+	home := t.TempDir()
+	profile := t.TempDir()
+	t.Setenv(agentroots.ClaudeListEnv, profile)
+
+	writeTitleFile(t, filepath.Join(profile, "projects", "home-user-app", "unrelated.jsonl"), "First root title")
+	writeTitleFile(t, filepath.Join(home, ".claude", "projects", "home-user-app", "wanted.jsonl"), "Second root title")
+
+	r := NewResolver(home)
+	if len(r.claudeRoots) != 2 || r.claudeRoots[0] != filepath.Join(profile, "projects") {
+		t.Fatalf("claudeRoots = %v, want the configured profile first and the home default kept", r.claudeRoots)
+	}
+	if got := r.SessionName("claude", "/home/user/app", "wanted"); got != "Second root title" {
+		t.Fatalf("session name = %q, want %q", got, "Second root title")
+	}
+}
+
+func TestOMPSessionPathAcceptedFromNonDefaultRoot(t *testing.T) {
+	clearAgentRootEnv(t)
+	home := t.TempDir()
+	profile := t.TempDir()
+	t.Setenv(agentroots.OMPListEnv, profile)
+
+	sessionPath := filepath.Join(profile, "sessions", "-home-user-app", "s.jsonl")
+	if err := os.MkdirAll(filepath.Dir(sessionPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(sessionPath, []byte("{\"type\":\"title\",\"title\":\"profile_omp\"}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := NewResolver(home).SessionName("omp", "/home/user/app", sessionPath); got != "profile_omp" {
+		t.Fatalf("session name = %q, want %q", got, "profile_omp")
+	}
+}
+
+// Containment regression guard: a path outside every configured root is
+// rejected even though one configured root resolves fine.
+func TestOMPSessionPathRejectedOutsideEveryRoot(t *testing.T) {
+	clearAgentRootEnv(t)
+	home := t.TempDir()
+	profile := t.TempDir()
+	outside := t.TempDir()
+	t.Setenv(agentroots.OMPListEnv, profile)
+
+	if err := os.MkdirAll(filepath.Join(profile, "sessions"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	outsidePath := filepath.Join(outside, "escaped.jsonl")
+	if err := os.WriteFile(outsidePath, []byte("{\"type\":\"title\",\"title\":\"escaped_title\"}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := NewResolver(home).SessionName("omp", "/home/user/app", outsidePath); got != "" {
+		t.Fatalf("session name = %q, want empty for a path outside every root", got)
+	}
+}
+
+// Containment regression guard: a symlink sitting inside a configured root but
+// resolving outside every root is rejected, because the check evaluates
+// symlinks before comparing.
+func TestOMPSessionPathRejectedSymlinkEscapingEveryRoot(t *testing.T) {
+	clearAgentRootEnv(t)
+	home := t.TempDir()
+	profile := t.TempDir()
+	outside := t.TempDir()
+	t.Setenv(agentroots.OMPListEnv, profile)
+
+	target := filepath.Join(outside, "escaped.jsonl")
+	if err := os.WriteFile(target, []byte("{\"type\":\"title\",\"title\":\"escaped_title\"}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(profile, "sessions", "-home-user-app", "link.jsonl")
+	if err := os.MkdirAll(filepath.Dir(link), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := NewResolver(home).SessionName("omp", "/home/user/app", link); got != "" {
+		t.Fatalf("session name = %q, want empty for a symlink escaping every root", got)
+	}
+}
+
+func TestCodexTitleFromSecondConfiguredHome(t *testing.T) {
+	clearAgentRootEnv(t)
+	home := t.TempDir()
+	first := t.TempDir()
+	second := t.TempDir()
+	t.Setenv(agentroots.CodexListEnv, strings.Join([]string{first, second}, string(filepath.ListSeparator)))
+
+	data, err := json.Marshal(map[string]any{"id": "sess-second", "thread_name": "Second home thread"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(second, "session_index.jsonl"), append(data, '\n'), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := NewResolver(home).SessionName("codex", "/tmp", "sess-second"); got != "Second home thread" {
+		t.Fatalf("session name = %q, want %q; the first home has no index file and must not end the search", got, "Second home thread")
+	}
+}
+
+// Mirrors TestCacheTTL, but for a session reachable only through a non-default
+// root: sourceSignature has to sign the file the title actually came from.
+func TestCacheInvalidationWithNonDefaultClaudeRoot(t *testing.T) {
+	clearAgentRootEnv(t)
+	home := t.TempDir()
+	profile := t.TempDir()
+	t.Setenv(agentroots.ClaudeListEnv, profile)
+
+	sessionFile := filepath.Join(profile, "projects", "home-user-proj", "s1.jsonl")
+	writeTitleFile(t, sessionFile, "First Title")
+
+	r := NewResolver(home)
+	if got := r.SessionName("claude", "/home/user/proj", "s1"); got != "First Title" {
+		t.Fatalf("first call = %q, want %q", got, "First Title")
+	}
+
+	writeTitleFile(t, sessionFile, "Second Title After Rename")
+	if got := r.SessionName("claude", "/home/user/proj", "s1"); got != "Second Title After Rename" {
+		t.Fatalf("refreshed call = %q, want %q", got, "Second Title After Rename")
+	}
+}
+
+// Regression guard for the title cache. projectSessionTitle keeps searching
+// roots until one yields a non-empty title, so sourceSignature must sign the
+// candidate in EVERY root. Signing only the first root that happens to have a
+// project directory for this cwd - which it did - signs a file the title never
+// came from, and the cached title then survives an edit to the file it really
+// came from for the whole 60s TTL.
+func TestTitleCacheTracksTheRootTheTitleActuallyCameFrom(t *testing.T) {
+	clearAgentRootEnv(t)
+	home := t.TempDir()
+	first := t.TempDir()
+	second := t.TempDir()
+	t.Setenv(agentroots.ClaudeListEnv, first+string(os.PathListSeparator)+second)
+
+	// The first root has a project directory for this cwd but NOT this session,
+	// so the title has to come from the second root.
+	writeTitleFile(t, filepath.Join(first, "projects", "home-user-app", "other.jsonl"), "Unrelated")
+	target := filepath.Join(second, "projects", "home-user-app", "wanted.jsonl")
+	writeTitleFile(t, target, "First Title")
+
+	r := NewResolver(home)
+	if got := r.SessionName("claude", "/home/user/app", "wanted"); got != "First Title" {
+		t.Fatalf("first call = %q, want %q from the second root", got, "First Title")
+	}
+
+	writeTitleFile(t, target, "Renamed Title")
+	if got := r.SessionName("claude", "/home/user/app", "wanted"); got != "Renamed Title" {
+		t.Fatalf("second call = %q, want %q - the cache signed the wrong root", got, "Renamed Title")
 	}
 }


### PR DESCRIPTION
Agent transcript roots were resolved ad hoc at each call site, and session titles were
resolved against a *different* set of roots than the transcripts themselves. Two consequences:

- A session whose transcript the relay could read could still show the wrong title, or none, because
  the title lookup searched somewhere else.
- Pi and Oh My Pi named profiles were invisible. Both place a profile's sessions under
  `<config root>/profiles/<name>/agent/sessions`, so a pane running any non-default profile had no
  discoverable transcript at all — the common one-profile-per-herdr-setup case.

### Change

- `internal/agentroots` — one seam that produces the ordered, de-duplicated root list per agent.
  Order is: the relay's own platform list variable (`HERDR_<AGENT>_CONFIG_DIRS`), then the agent's own
  single-directory variable, then directories discovered on disk, then the home default. Explicit
  configuration always outranks discovery, and the home default stays last.
- Session titles now resolve through that same seam, so a title and its transcript always come from
  the same tree.
- Named-profile session roots are discovered with no configuration.
- `README.md` / `.env.example` document the per-agent override variables.
- Tests pin the widening guarantee for the legacy single-directory variables: anything that resolved
  before still resolves.

One behavioural note worth a reviewer's attention: where the *same* session id exists in both the home
default and a configured root, the configured root now wins. That is the point of the change — the title
then agrees with the transcript the reader already took from the configured root — but it is a change,
not a pure widening.

### Verification

`go test -count=1 ./internal/agentroots/... ./internal/session/... ./internal/conversation/... ./internal/app/...`
all green on top of `main`, and still green with `PI_CODING_AGENT_DIR`, `CLAUDE_CONFIG_DIR`, `CODEX_HOME`
and the `HERDR_*_CONFIG_DIRS` variables stripped from the environment, so the tests are not passing on
ambient state. `gofmt -l internal` empty, `go vet ./...` clean. No dependency changes.

The last commit fixes test hygiene this feature itself introduced: making the resolver read those
variables left eleven pre-existing tests in `internal/session/resolver_test.go` able to fail from a
developer's exported environment. Proven, not theoretical — with `CLAUDE_CONFIG_DIR` pointing at a
profile holding a colliding session id, `TestClaudeSessionName` reported the ambient title. The
variables are now cleared once in `TestMain`, so a test added later cannot reintroduce the leak.

### Scope

`internal/agentroots` (new), `internal/conversation/reader.go`, `internal/session/resolver.go`,
`README.md`, `.env.example`, plus tests. Independent of my Claude block-array PR.

---

**Interaction with #16:** #15 and #16 both append test functions at the end of
`internal/conversation/reader_test.go`, so whichever lands second needs a trivial rebase — the
resolution is the union of both sides, no judgement call. I verified that merging the two produces a
tree identical to my local integration branch and that all four affected packages stay green.