### PR TITLE
feat: discover each agent's own skills for the slash-command palette

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,3 +38,11 @@ WEB_PROJECT=herdr-mobile-relay
 #   HERDR_TRANSPORT_FORCE_RELAY=0   Test flag: 1 disables the direct WebRTC
 #                                   upgrade and keeps every frame on the gateway
 #                                   path. Default 0.
+#   HERDR_CLAUDE_CONFIG_DIRS=       Extra Claude Code config dirs, colon-
+#                                   separated, added to the ~/.claude default. See
+#                                   README.md: "Agents with a non-default config
+#                                   directory".
+#   HERDR_QODER_CONFIG_DIRS=        Same, for Qoder CLI; added to ~/.qoder.
+#   HERDR_CODEX_CONFIG_DIRS=        Same, for Codex; added to ~/.codex.
+#   HERDR_PI_CONFIG_DIRS=           Same, for Pi; added to ~/.pi/agent.
+#   HERDR_OMP_CONFIG_DIRS=          Same, for Oh My Pi; added to ~/.omp/agent.

--- a/README.md
+++ b/README.md
@@ -92,6 +92,53 @@ fallback; Cloudflare tunnel traffic stays on Cloudflare.
 - **[Permanent Cloudflare tunnel →](docs/cloudflare-tunnel.md)**
 - **[Run your own gateway →](docs/gateway-self-hosting.md)**
 
+## Agents with a non-default config directory
+
+The relay runs as a background launchd/systemd user service, so it never
+inherits the shell environment a Herdr pane runs in. If a pane sets
+`CLAUDE_CONFIG_DIR`, `PI_CODING_AGENT_DIR`, or similar to use a non-default
+profile — one per herdr setup — the pane title still resolves correctly, but
+the relay looks for the conversation transcript in the wrong directory, and
+the conversation view shows "No conversation log is available for this
+session."
+
+Tell the relay about every profile you use with one of these:
+
+| Variable | Home default it adds to | Agent's own directory variable |
+| --- | --- | --- |
+| `HERDR_CLAUDE_CONFIG_DIRS` | `~/.claude` | `CLAUDE_CONFIG_DIR` |
+| `HERDR_QODER_CONFIG_DIRS` | `~/.qoder` | none |
+| `HERDR_CODEX_CONFIG_DIRS` | `~/.codex` | `CODEX_HOME` |
+| `HERDR_PI_CONFIG_DIRS` | `~/.pi/agent` | `PI_CODING_AGENT_DIR` |
+| `HERDR_OMP_CONFIG_DIRS` | `~/.omp/agent` | `PI_CODING_AGENT_DIR` (Oh My Pi is a Pi fork and shares Pi's default) |
+
+Two things to get right:
+
+- The home default is always searched. Setting a list *adds* profiles; it
+  never replaces the default.
+- Entries are config directories — the same value you'd put in
+  `CLAUDE_CONFIG_DIR` — not pre-joined `projects`/`sessions` paths. The relay
+  appends the right leaf itself.
+
+Separate multiple entries with your platform's path-list separator (`:` on
+Unix, `;` on Windows), same as `PATH`.
+
+Set these in the file named by `HERDR_RELAY_ENV`: `$HERDR_PLUGIN_CONFIG_DIR/relay.env`
+for an installation, `relay/.env` for a checkout. For example, with two herdr
+setups using `~/agents/claude-work` and `~/agents/claude-personal` as their
+Claude profiles, add:
+
+```bash
+HERDR_CLAUDE_CONFIG_DIRS=~/agents/claude-work:~/agents/claude-personal
+```
+
+The service wrapper sources that file with `set -a`, so every key in it
+becomes part of the relay's environment — quote a path that contains spaces,
+since the file is parsed by bash. After editing, restart the relay: reopen
+the setup menu with the `herdr plugin pane open` command under **Get started
+in two minutes** above, then choose your connection option again. An
+already-installed background service is restarted rather than started twice.
+
 ## Documentation
 
 | Page | What is in it |

--- a/README.md
+++ b/README.md
@@ -102,7 +102,11 @@ the relay looks for the conversation transcript in the wrong directory, and
 the conversation view shows "No conversation log is available for this
 session."
 
-Tell the relay about every profile you use with one of these:
+Pi and Oh My Pi need no configuration for their named profiles: both keep a
+profile's sessions at `<config root>/profiles/<name>/agent`, so the relay
+discovers `~/.omp/profiles/*/agent` and `~/.pi/profiles/*/agent` on startup.
+Restart the relay after adding a profile. Every other case — and a Pi or Oh My
+Pi config root moved somewhere else — needs to be named explicitly:
 
 | Variable | Home default it adds to | Agent's own directory variable |
 | --- | --- | --- |
@@ -112,13 +116,15 @@ Tell the relay about every profile you use with one of these:
 | `HERDR_PI_CONFIG_DIRS` | `~/.pi/agent` | `PI_CODING_AGENT_DIR` |
 | `HERDR_OMP_CONFIG_DIRS` | `~/.omp/agent` | `PI_CODING_AGENT_DIR` (Oh My Pi is a Pi fork and shares Pi's default) |
 
-Two things to get right:
+Three things to get right:
 
 - The home default is always searched. Setting a list *adds* profiles; it
   never replaces the default.
 - Entries are config directories — the same value you'd put in
   `CLAUDE_CONFIG_DIR` — not pre-joined `projects`/`sessions` paths. The relay
   appends the right leaf itself.
+- What you configure is searched before what the relay discovered, and the home
+  default is searched last.
 
 Separate multiple entries with your platform's path-list separator (`:` on
 Unix, `;` on Windows), same as `PATH`.

--- a/internal/agentroots/agentroots.go
+++ b/internal/agentroots/agentroots.go
@@ -1,0 +1,101 @@
+// Package agentroots resolves the directories the relay searches for a coding
+// agent's transcript and session files.
+//
+// The relay runs as a launchd/systemd user service, so it does not inherit the
+// shell environment herdr uses when it spawns an agent pane. When an agent is
+// configured with a non-default config directory - one profile per herdr setup -
+// that per-pane value is invisible to the relay by construction.
+//
+// Every agent therefore resolves to a *list* of roots rather than a single one.
+// Order is: the relay's own platform path list (HERDR_<AGENT>_CONFIG_DIRS), the
+// agent's own single-directory variable, then the home default. The home default
+// is always appended, so configuring the list adds profiles instead of replacing
+// the default profile.
+//
+// Both the conversation reader and the session-title resolver resolve through
+// this package, which is what keeps a pane's title and its transcript from
+// being looked up in different trees.
+package agentroots
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Relay-side overrides. Each holds a platform-separated list (":" on Unix, ";"
+// on Windows, as in PATH) of *config directories* - the same values that would
+// go in CLAUDE_CONFIG_DIR and friends - not pre-joined transcript roots. The
+// service wrapper exports every key of relay.env into the relay process, so
+// these belong in that file.
+const (
+	ClaudeListEnv = "HERDR_CLAUDE_CONFIG_DIRS"
+	QoderListEnv  = "HERDR_QODER_CONFIG_DIRS"
+	CodexListEnv  = "HERDR_CODEX_CONFIG_DIRS"
+	PiListEnv     = "HERDR_PI_CONFIG_DIRS"
+	OMPListEnv    = "HERDR_OMP_CONFIG_DIRS"
+)
+
+// Claude reports the transcript roots for Claude Code, honouring
+// CLAUDE_CONFIG_DIR exactly as it did when a single root was resolved.
+func Claude(home string) []string {
+	return resolve(ClaudeListEnv, "CLAUDE_CONFIG_DIR", filepath.Join(home, ".claude"), "projects")
+}
+
+// Qoder reports the transcript roots for Qoder CLI, which has no config
+// directory variable of its own.
+func Qoder(home string) []string {
+	return resolve(QoderListEnv, "", filepath.Join(home, ".qoder"), "projects")
+}
+
+// Codex reports the rollout roots for OpenAI Codex.
+func Codex(home string) []string {
+	return resolve(CodexListEnv, "CODEX_HOME", filepath.Join(home, ".codex"), "sessions")
+}
+
+// CodexHomes reports the Codex config directories themselves, for consumers
+// that read a file stored beside the sessions tree (session_index.jsonl).
+func CodexHomes(home string) []string {
+	return resolve(CodexListEnv, "CODEX_HOME", filepath.Join(home, ".codex"), "")
+}
+
+// Pi reports the session roots for the Pi coding agent.
+func Pi(home string) []string {
+	return resolve(PiListEnv, "PI_CODING_AGENT_DIR", filepath.Join(home, ".pi", "agent"), "sessions")
+}
+
+// OMP reports the session roots for Oh My Pi. Oh My Pi is a Pi fork and reads
+// the same PI_CODING_AGENT_DIR override for its default profile; named profiles
+// ignore that variable and live under <config root>/profiles/<name>/agent,
+// which is what HERDR_OMP_CONFIG_DIRS is for.
+func OMP(home string) []string {
+	return resolve(OMPListEnv, "PI_CODING_AGENT_DIR", filepath.Join(home, ".omp", "agent"), "sessions")
+}
+
+// resolve builds the ordered, de-duplicated root list for one agent. singleEnv
+// may be empty for agents without a config directory variable. leaf may be
+// empty to report the config directories themselves.
+func resolve(listEnv, singleEnv, homeBase, leaf string) []string {
+	seen := make(map[string]bool, 4)
+	roots := make([]string, 0, 4)
+	add := func(base string) {
+		base = strings.TrimSpace(base)
+		if base == "" {
+			return
+		}
+		root := filepath.Join(base, leaf)
+		if seen[root] {
+			return
+		}
+		seen[root] = true
+		roots = append(roots, root)
+	}
+	for _, base := range filepath.SplitList(os.Getenv(listEnv)) {
+		add(base)
+	}
+	if singleEnv != "" {
+		add(os.Getenv(singleEnv))
+	}
+	add(homeBase)
+	return roots
+}

--- a/internal/agentroots/agentroots.go
+++ b/internal/agentroots/agentroots.go
@@ -90,6 +90,46 @@ func OMP(home string) []string {
 		profileAgentDirs(configRoot)...)
 }
 
+// OMPSkillDirs reports the directories holding Oh My Pi's own (native) skills,
+// one per agent directory resolved for OMP.
+func OMPSkillDirs(home string) []string {
+	configRoot := filepath.Join(home, ".omp")
+	return resolve(OMPListEnv, "PI_CODING_AGENT_DIR", filepath.Join(configRoot, "agent"), "skills",
+		profileAgentDirs(configRoot)...)
+}
+
+// OMPManagedSkillDirs reports the directories holding Oh My Pi's managed skills,
+// the ones the agent mints for itself.
+func OMPManagedSkillDirs(home string) []string {
+	configRoot := filepath.Join(home, ".omp")
+	return resolve(OMPListEnv, "PI_CODING_AGENT_DIR", filepath.Join(configRoot, "agent"), "managed-skills",
+		profileAgentDirs(configRoot)...)
+}
+
+// OMPConfigDirs reports the Oh My Pi agent directories themselves, where
+// config.yml lives. A named profile keeps its own config file, so this is the
+// only way to reach the settings that actually apply to a profile's pane.
+func OMPConfigDirs(home string) []string {
+	configRoot := filepath.Join(home, ".omp")
+	return resolve(OMPListEnv, "PI_CODING_AGENT_DIR", filepath.Join(configRoot, "agent"), "",
+		profileAgentDirs(configRoot)...)
+}
+
+// PiSkillDirs reports the directories holding Pi's own skills.
+func PiSkillDirs(home string) []string {
+	configRoot := filepath.Join(home, ".pi")
+	return resolve(PiListEnv, "PI_CODING_AGENT_DIR", filepath.Join(configRoot, "agent"), "skills",
+		profileAgentDirs(configRoot)...)
+}
+
+// PiConfigDirs reports the Pi agent directories themselves, where settings.json
+// lives.
+func PiConfigDirs(home string) []string {
+	configRoot := filepath.Join(home, ".pi")
+	return resolve(PiListEnv, "PI_CODING_AGENT_DIR", filepath.Join(configRoot, "agent"), "",
+		profileAgentDirs(configRoot)...)
+}
+
 // profileAgentDirs reports the agent directory of every named profile under a
 // config root. Pi and Oh My Pi place one at <config root>/profiles/<name>/agent
 // - verified against the omp bundle, which builds exactly

--- a/internal/agentroots/agentroots.go
+++ b/internal/agentroots/agentroots.go
@@ -8,9 +8,10 @@
 //
 // Every agent therefore resolves to a *list* of roots rather than a single one.
 // Order is: the relay's own platform path list (HERDR_<AGENT>_CONFIG_DIRS), the
-// agent's own single-directory variable, then the home default. The home default
-// is always appended, so configuring the list adds profiles instead of replacing
-// the default profile.
+// agent's own single-directory variable, then any profile directories discovered
+// on disk (Pi and Oh My Pi only), then the home default. The home default is
+// always appended, so configuring the list adds profiles instead of replacing
+// the default profile, and configuration always outranks discovery.
 //
 // Both the conversation reader and the session-title resolver resolve through
 // this package, which is what keeps a pane's title and its transcript from
@@ -59,25 +60,91 @@ func CodexHomes(home string) []string {
 	return resolve(CodexListEnv, "CODEX_HOME", filepath.Join(home, ".codex"), "")
 }
 
-// Pi reports the session roots for the Pi coding agent.
+// Pi reports the session roots for the Pi coding agent, including the agent
+// directory of every named profile found under its config root.
 func Pi(home string) []string {
-	return resolve(PiListEnv, "PI_CODING_AGENT_DIR", filepath.Join(home, ".pi", "agent"), "sessions")
+	configRoot := filepath.Join(home, ".pi")
+	return resolve(PiListEnv, "PI_CODING_AGENT_DIR", filepath.Join(configRoot, "agent"), "sessions",
+		profileAgentDirs(configRoot)...)
 }
 
-// OMP reports the session roots for Oh My Pi. Oh My Pi is a Pi fork and reads
-// the same PI_CODING_AGENT_DIR override for its default profile; named profiles
-// ignore that variable and live under <config root>/profiles/<name>/agent,
-// which is what HERDR_OMP_CONFIG_DIRS is for.
+// OMP reports the session roots for Oh My Pi, including the agent directory of
+// every named profile found under its config root.
+//
+// Oh My Pi is a Pi fork and reads the same PI_CODING_AGENT_DIR override, but
+// only while no profile is active: verified against the omp 18.0.3 bundle, where
+// `agentDirOverride` is passed as `t ? undefined : e.agentDirOverride` and `t` is
+// the resolved profile. There is no OMP_AGENT_DIR, OMP_CODING_AGENT_DIR or
+// OMP_CONFIG_DIR - none of those strings occur in the binary at all.
+//
+// Note the asymmetry, because it is easy to misread the above as "a profile has
+// nothing to do with this variable": omp *ignores* PI_CODING_AGENT_DIR as an
+// input under a profile, but it *exports* the resolved agent directory back into
+// the environment of what it spawns, so a pane running a profile does carry a
+// PI_CODING_AGENT_DIR pointing at that profile. That is of no use here - the
+// relay cannot read a pane's environment, which is the whole reason this package
+// exists - but it is why discovery, not the variable, is what finds profiles.
 func OMP(home string) []string {
-	return resolve(OMPListEnv, "PI_CODING_AGENT_DIR", filepath.Join(home, ".omp", "agent"), "sessions")
+	configRoot := filepath.Join(home, ".omp")
+	return resolve(OMPListEnv, "PI_CODING_AGENT_DIR", filepath.Join(configRoot, "agent"), "sessions",
+		profileAgentDirs(configRoot)...)
+}
+
+// profileAgentDirs reports the agent directory of every named profile under a
+// config root. Pi and Oh My Pi place one at <config root>/profiles/<name>/agent
+// - verified against the omp bundle, which builds exactly
+// `join(configRoot, "profiles", name, "agent")` - and a profile makes the agent
+// ignore PI_CODING_AGENT_DIR, so a profile's sessions are reachable no other
+// way. Discovering them is what lets the common one-profile-per-herdr-setup
+// layout work with no configuration at all.
+//
+// Only the home default's config root is expanded. An explicitly configured
+// entry is itself an agent directory, so treating its parent as a config root
+// would be wrong. A relocated config root - omp resolves that through
+// PI_CONFIG_DIR and XDG probing - is what the HERDR_*_CONFIG_DIRS lists are
+// for; mirroring that resolution here would couple the relay to omp's
+// internals and drift out of step with them.
+//
+// os.ReadDir sorts its result, so the discovered order is deterministic.
+//
+// Entries are classified with os.Stat, not DirEntry.IsDir. DirEntry reports the
+// directory entry's own type bits, which are ModeSymlink for a symlink, so
+// IsDir() is false for a symlink to a directory and a profile reached through
+// one would be silently skipped. omp joins the path and follows it, so the
+// relay has to as well; symlinked profile directories are a normal way to keep
+// agent configuration on another volume or in a dotfiles repo.
+func profileAgentDirs(configRoot string) []string {
+	// A relative config root would make this scan directories under the relay's
+	// working directory, which is never what the caller means. This happens only
+	// when os.UserHomeDir() failed and home is empty.
+	if !filepath.IsAbs(configRoot) {
+		return nil
+	}
+	profiles := filepath.Join(configRoot, "profiles")
+	entries, err := os.ReadDir(profiles)
+	if err != nil {
+		return nil
+	}
+	dirs := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		candidate := filepath.Join(profiles, entry.Name())
+		info, err := os.Stat(candidate)
+		if err != nil || !info.IsDir() {
+			continue
+		}
+		dirs = append(dirs, filepath.Join(candidate, "agent"))
+	}
+	return dirs
 }
 
 // resolve builds the ordered, de-duplicated root list for one agent. singleEnv
 // may be empty for agents without a config directory variable. leaf may be
-// empty to report the config directories themselves.
-func resolve(listEnv, singleEnv, homeBase, leaf string) []string {
-	seen := make(map[string]bool, 4)
-	roots := make([]string, 0, 4)
+// empty to report the config directories themselves. discovered bases are
+// appended after the environment ones and before the home default, so
+// configuration always wins over discovery and the home default stays last.
+func resolve(listEnv, singleEnv, homeBase, leaf string, discovered ...string) []string {
+	seen := make(map[string]bool, 4+len(discovered))
+	roots := make([]string, 0, 4+len(discovered))
 	add := func(base string) {
 		base = strings.TrimSpace(base)
 		if base == "" {
@@ -95,6 +162,9 @@ func resolve(listEnv, singleEnv, homeBase, leaf string) []string {
 	}
 	if singleEnv != "" {
 		add(os.Getenv(singleEnv))
+	}
+	for _, base := range discovered {
+		add(base)
 	}
 	add(homeBase)
 	return roots

--- a/internal/agentroots/agentroots_test.go
+++ b/internal/agentroots/agentroots_test.go
@@ -229,3 +229,261 @@ func TestOMPAndPiRoots(t *testing.T) {
 		}
 	})
 }
+
+// A named profile makes Oh My Pi ignore PI_CODING_AGENT_DIR entirely, so a
+// profile's sessions are reachable no other way than by knowing the layout.
+// Discovering <config root>/profiles/<name>/agent is what makes the common
+// one-profile-per-herdr-setup case work with no configuration at all.
+func TestOMPDiscoversNamedProfileAgentDirs(t *testing.T) {
+	clearAllEnv(t)
+	home := t.TempDir()
+	for _, name := range []string{"personal", "work"} {
+		if err := os.MkdirAll(filepath.Join(home, ".omp", "profiles", name, "agent", "sessions"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// A stray file under profiles/ must not become a root.
+	if err := os.WriteFile(filepath.Join(home, ".omp", "profiles", "notes.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := OMP(home)
+	want := []string{
+		filepath.Join(home, ".omp", "profiles", "personal", "agent", "sessions"),
+		filepath.Join(home, ".omp", "profiles", "work", "agent", "sessions"),
+		filepath.Join(home, ".omp", "agent", "sessions"),
+	}
+	if !slices.Equal(got, want) {
+		t.Fatalf("OMP(home) = %v, want discovered profiles then the home default %v", got, want)
+	}
+}
+
+// Discovery must not disturb configuration precedence: an explicitly configured
+// directory still comes first, and the home default still comes last.
+func TestOMPConfigurationOutranksDiscoveredProfiles(t *testing.T) {
+	clearAllEnv(t)
+	home := t.TempDir()
+	explicit := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(home, ".omp", "profiles", "personal", "agent"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(OMPListEnv, explicit)
+
+	got := OMP(home)
+	want := []string{
+		filepath.Join(explicit, "sessions"),
+		filepath.Join(home, ".omp", "profiles", "personal", "agent", "sessions"),
+		filepath.Join(home, ".omp", "agent", "sessions"),
+	}
+	if !slices.Equal(got, want) {
+		t.Fatalf("OMP(home) = %v, want %v", got, want)
+	}
+}
+
+// Discovery is additive: with no profiles directory the result is exactly what
+// it was before discovery existed, so a default install is unaffected.
+func TestDiscoveryIsANoOpWithoutProfiles(t *testing.T) {
+	clearAllEnv(t)
+	home := t.TempDir()
+	for _, c := range []struct {
+		name string
+		got  []string
+		want []string
+	}{
+		{"OMP", OMP(home), []string{filepath.Join(home, ".omp", "agent", "sessions")}},
+		{"Pi", Pi(home), []string{filepath.Join(home, ".pi", "agent", "sessions")}},
+	} {
+		if !slices.Equal(c.got, c.want) {
+			t.Errorf("%s(home) = %v, want %v", c.name, c.got, c.want)
+		}
+	}
+}
+
+// An explicitly configured entry is an agent directory, not a config root, so
+// its sibling profiles/ must never be expanded.
+func TestDiscoveryDoesNotExpandConfiguredEntries(t *testing.T) {
+	clearAllEnv(t)
+	home := t.TempDir()
+	explicit := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(explicit, "profiles", "sneaky", "agent"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(OMPListEnv, filepath.Join(explicit, "agent"))
+
+	roots := OMP(home)
+	for _, root := range roots {
+		if strings.Contains(root, "sneaky") {
+			t.Fatalf("expanded a configured entry's profiles/: %v", roots)
+		}
+	}
+}
+
+// Pi gets the same treatment as OMP, under its own config root, and the two
+// must not bleed into each other.
+func TestPiDiscoversNamedProfileAgentDirs(t *testing.T) {
+	clearAllEnv(t)
+	home := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(home, ".pi", "profiles", "alt", "agent"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	got := Pi(home)
+	want := []string{
+		filepath.Join(home, ".pi", "profiles", "alt", "agent", "sessions"),
+		filepath.Join(home, ".pi", "agent", "sessions"),
+	}
+	if !slices.Equal(got, want) {
+		t.Fatalf("Pi(home) = %v, want %v", got, want)
+	}
+	for _, root := range OMP(home) {
+		if strings.Contains(root, ".pi") {
+			t.Fatalf("OMP root list contains a Pi path: %v", OMP(home))
+		}
+	}
+}
+
+// The seam classifies profile entries with os.Stat, not DirEntry.IsDir, because
+// DirEntry reports the entry's own type bits (ModeSymlink for a symlink), so a
+// profile reached through a symlink used to be silently skipped even though omp
+// itself joins and follows that path. The discovered root uses the lexical path
+// through the symlink - containment resolution happens later, not here.
+func TestOMPDiscoversProfileReachedThroughASymlink(t *testing.T) {
+	clearAllEnv(t)
+	home := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(home, ".omp", "profiles", "personal", "agent"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	target := t.TempDir()
+	link := filepath.Join(home, ".omp", "profiles", "linked")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+
+	got := OMP(home)
+	want := []string{
+		// "linked" sorts before "personal" in os.ReadDir's order.
+		filepath.Join(home, ".omp", "profiles", "linked", "agent", "sessions"),
+		filepath.Join(home, ".omp", "profiles", "personal", "agent", "sessions"),
+		filepath.Join(home, ".omp", "agent", "sessions"),
+	}
+	if !slices.Equal(got, want) {
+		t.Fatalf("OMP(home) = %v, want the symlinked profile (lexical path, unresolved) and the real "+
+			"profile in os.ReadDir order, then the home default: %v", got, want)
+	}
+}
+
+// A dangling symlink or a plain file directly under profiles/ must not become
+// a root: os.Stat on a dangling symlink errors, and a regular file is not a
+// directory either way.
+func TestDiscoverySkipsBrokenSymlinksAndFiles(t *testing.T) {
+	clearAllEnv(t)
+	home := t.TempDir()
+	profiles := filepath.Join(home, ".omp", "profiles")
+	if err := os.MkdirAll(profiles, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(filepath.Join(home, "nowhere"), filepath.Join(profiles, "broken")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(profiles, "afile.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := OMP(home)
+	want := []string{filepath.Join(home, ".omp", "agent", "sessions")}
+	if !slices.Equal(got, want) {
+		t.Fatalf("OMP(home) = %v, want exactly the home default (broken symlink and file must be skipped): %v", got, want)
+	}
+}
+
+// profileAgentDirs returns nil for a non-absolute config root, which happens
+// only when os.UserHomeDir() failed and home is "". Without that guard, a
+// relative root would scan under the relay's working directory instead. The
+// working directory here deliberately contains a profiles/ layout that a
+// relative scan would find, so the assertion is non-vacuous.
+func TestDiscoveryIgnoresRelativeConfigRoot(t *testing.T) {
+	clearAllEnv(t)
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, ".omp", "profiles", "x", "agent"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, ".pi", "profiles", "y", "agent"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(dir)
+
+	for _, c := range []struct {
+		name string
+		got  []string
+	}{
+		{"OMP", OMP("")},
+		{"Pi", Pi("")},
+	} {
+		for _, root := range c.got {
+			if strings.Contains(root, "profiles") {
+				t.Fatalf("%s(\"\") = %v, want no profiles/ path from a relative config root", c.name, c.got)
+			}
+		}
+	}
+}
+
+// A discovered profile whose agent directory is also named explicitly in
+// HERDR_OMP_CONFIG_DIRS must not appear twice: resolve's de-duplication keys
+// on the final joined root, and the configured occurrence - added first -
+// must be the one that wins the position.
+func TestDiscoveredProfileDedupesAgainstAnIdenticalConfiguredEntry(t *testing.T) {
+	clearAllEnv(t)
+	home := t.TempDir()
+	profileAgent := filepath.Join(home, ".omp", "profiles", "personal", "agent")
+	if err := os.MkdirAll(profileAgent, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(OMPListEnv, profileAgent)
+
+	got := OMP(home)
+	root := filepath.Join(profileAgent, "sessions")
+	count := 0
+	for _, r := range got {
+		if r == root {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("OMP(home) = %v contains %d occurrences of %q, want exactly 1", got, count, root)
+	}
+	if len(got) == 0 || got[0] != root {
+		t.Fatalf("OMP(home) = %v, want the configured entry %q first", got, root)
+	}
+	want := []string{root, filepath.Join(home, ".omp", "agent", "sessions")}
+	if !slices.Equal(got, want) {
+		t.Fatalf("OMP(home) = %v, want %v", got, want)
+	}
+}
+
+// A profiles/ directory that cannot be read (permissions, not absence) must
+// degrade to the home default rather than panicking or propagating an error.
+func TestDiscoveryUnreadableProfilesDirIsANoOp(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root: chmod 0o000 does not block directory reads for root")
+	}
+	clearAllEnv(t)
+	home := t.TempDir()
+	profiles := filepath.Join(home, ".omp", "profiles")
+	if err := os.MkdirAll(profiles, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(profiles, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chmod(profiles, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	got := OMP(home)
+	want := []string{filepath.Join(home, ".omp", "agent", "sessions")}
+	if !slices.Equal(got, want) {
+		t.Fatalf("OMP(home) = %v, want exactly the home default when profiles/ is unreadable: %v", got, want)
+	}
+}

--- a/internal/agentroots/agentroots_test.go
+++ b/internal/agentroots/agentroots_test.go
@@ -1,0 +1,231 @@
+package agentroots
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+)
+
+// clearAllEnv resets every environment variable agentroots reads, so a
+// developer's shell exports (or a previous subtest) cannot leak into the
+// next scenario.
+func clearAllEnv(t *testing.T) {
+	t.Helper()
+	for _, name := range []string{
+		"CLAUDE_CONFIG_DIR", "CODEX_HOME", "PI_CODING_AGENT_DIR",
+		ClaudeListEnv, QoderListEnv, CodexListEnv, PiListEnv, OMPListEnv,
+	} {
+		t.Setenv(name, "")
+	}
+}
+
+func TestClaudeRoots(t *testing.T) {
+	t.Run("home default only", func(t *testing.T) {
+		clearAllEnv(t)
+		home := t.TempDir()
+		want := []string{filepath.Join(home, ".claude", "projects")}
+		if got := Claude(home); !slices.Equal(got, want) {
+			t.Fatalf("Claude(%q) = %v, want %v", home, got, want)
+		}
+	})
+
+	t.Run("single env var still honoured", func(t *testing.T) {
+		clearAllEnv(t)
+		home := t.TempDir()
+		t.Setenv("CLAUDE_CONFIG_DIR", "/a")
+		want := []string{
+			filepath.Join("/a", "projects"),
+			filepath.Join(home, ".claude", "projects"),
+		}
+		if got := Claude(home); !slices.Equal(got, want) {
+			t.Fatalf("Claude(%q) = %v, want %v", home, got, want)
+		}
+	})
+
+	t.Run("list env adds and comes first", func(t *testing.T) {
+		clearAllEnv(t)
+		home := t.TempDir()
+		t.Setenv(ClaudeListEnv, "/x")
+		t.Setenv("CLAUDE_CONFIG_DIR", "/a")
+		want := []string{
+			filepath.Join("/x", "projects"),
+			filepath.Join("/a", "projects"),
+			filepath.Join(home, ".claude", "projects"),
+		}
+		if got := Claude(home); !slices.Equal(got, want) {
+			t.Fatalf("Claude(%q) = %v, want %v", home, got, want)
+		}
+	})
+
+	t.Run("multi entry list keeps order", func(t *testing.T) {
+		clearAllEnv(t)
+		home := t.TempDir()
+		t.Setenv(ClaudeListEnv, strings.Join([]string{"/x", "/y"}, string(os.PathListSeparator)))
+		want := []string{
+			filepath.Join("/x", "projects"),
+			filepath.Join("/y", "projects"),
+			filepath.Join(home, ".claude", "projects"),
+		}
+		if got := Claude(home); !slices.Equal(got, want) {
+			t.Fatalf("Claude(%q) = %v, want %v", home, got, want)
+		}
+	})
+
+	t.Run("de-duplication of list entry against single var", func(t *testing.T) {
+		clearAllEnv(t)
+		home := t.TempDir()
+		t.Setenv(ClaudeListEnv, "/a")
+		t.Setenv("CLAUDE_CONFIG_DIR", "/a")
+		want := []string{
+			filepath.Join("/a", "projects"),
+			filepath.Join(home, ".claude", "projects"),
+		}
+		if got := Claude(home); !slices.Equal(got, want) {
+			t.Fatalf("Claude(%q) = %v, want %v", home, got, want)
+		}
+	})
+
+	t.Run("de-duplication of list entry against home base", func(t *testing.T) {
+		clearAllEnv(t)
+		home := t.TempDir()
+		t.Setenv(ClaudeListEnv, filepath.Join(home, ".claude"))
+		want := []string{filepath.Join(home, ".claude", "projects")}
+		if got := Claude(home); !slices.Equal(got, want) {
+			t.Fatalf("Claude(%q) = %v, want %v", home, got, want)
+		}
+	})
+
+	t.Run("blank and whitespace-only entries are skipped", func(t *testing.T) {
+		clearAllEnv(t)
+		home := t.TempDir()
+		t.Setenv(ClaudeListEnv, strings.Join([]string{"/x", "", "  ", "/y"}, string(os.PathListSeparator)))
+		want := []string{
+			filepath.Join("/x", "projects"),
+			filepath.Join("/y", "projects"),
+			filepath.Join(home, ".claude", "projects"),
+		}
+		if got := Claude(home); !slices.Equal(got, want) {
+			t.Fatalf("Claude(%q) = %v, want %v", home, got, want)
+		}
+	})
+}
+
+func TestQoderRoots(t *testing.T) {
+	t.Run("no single var override", func(t *testing.T) {
+		clearAllEnv(t)
+		home := t.TempDir()
+		t.Setenv("CLAUDE_CONFIG_DIR", "/should-not-affect-qoder")
+		t.Setenv("CODEX_HOME", "/also-should-not-affect-qoder")
+		t.Setenv("PI_CODING_AGENT_DIR", "/nor-this")
+		want := []string{filepath.Join(home, ".qoder", "projects")}
+		if got := Qoder(home); !slices.Equal(got, want) {
+			t.Fatalf("Qoder(%q) = %v, want %v (single-dir env vars must not affect Qoder)", home, got, want)
+		}
+	})
+
+	t.Run("home default and list env", func(t *testing.T) {
+		clearAllEnv(t)
+		home := t.TempDir()
+		t.Setenv(QoderListEnv, "/q")
+		want := []string{
+			filepath.Join("/q", "projects"),
+			filepath.Join(home, ".qoder", "projects"),
+		}
+		if got := Qoder(home); !slices.Equal(got, want) {
+			t.Fatalf("Qoder(%q) = %v, want %v", home, got, want)
+		}
+	})
+}
+
+func TestCodexRootsAndHomes(t *testing.T) {
+	scenarios := []struct {
+		name  string
+		setup func(t *testing.T)
+	}{
+		{name: "default only", setup: func(t *testing.T) {}},
+		{name: "CODEX_HOME override", setup: func(t *testing.T) {
+			t.Setenv("CODEX_HOME", "/c")
+		}},
+		{name: "list env adds and comes first", setup: func(t *testing.T) {
+			t.Setenv(CodexListEnv, "/c1")
+			t.Setenv("CODEX_HOME", "/c2")
+		}},
+	}
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+			clearAllEnv(t)
+			home := t.TempDir()
+			scenario.setup(t)
+
+			sessions := Codex(home)
+			homes := CodexHomes(home)
+			if len(sessions) != len(homes) {
+				t.Fatalf("len(Codex(home)) = %d, len(CodexHomes(home)) = %d, want equal (%v vs %v)", len(sessions), len(homes), sessions, homes)
+			}
+			for index := range homes {
+				want := filepath.Join(homes[index], "sessions")
+				if sessions[index] != want {
+					t.Fatalf("Codex(home)[%d] = %q, want %q (= filepath.Join(CodexHomes(home)[%d], \"sessions\"))", index, sessions[index], want, index)
+				}
+			}
+		})
+	}
+}
+
+func TestOMPAndPiRoots(t *testing.T) {
+	t.Run("distinct home defaults", func(t *testing.T) {
+		clearAllEnv(t)
+		home := t.TempDir()
+		wantPi := []string{filepath.Join(home, ".pi", "agent", "sessions")}
+		wantOMP := []string{filepath.Join(home, ".omp", "agent", "sessions")}
+		if got := Pi(home); !slices.Equal(got, wantPi) {
+			t.Fatalf("Pi(%q) = %v, want %v", home, got, wantPi)
+		}
+		if got := OMP(home); !slices.Equal(got, wantOMP) {
+			t.Fatalf("OMP(%q) = %v, want %v", home, got, wantOMP)
+		}
+	})
+
+	t.Run("shared single var, distinct base", func(t *testing.T) {
+		clearAllEnv(t)
+		home := t.TempDir()
+		t.Setenv("PI_CODING_AGENT_DIR", "/shared")
+		wantPi := []string{
+			filepath.Join("/shared", "sessions"),
+			filepath.Join(home, ".pi", "agent", "sessions"),
+		}
+		wantOMP := []string{
+			filepath.Join("/shared", "sessions"),
+			filepath.Join(home, ".omp", "agent", "sessions"),
+		}
+		if got := Pi(home); !slices.Equal(got, wantPi) {
+			t.Fatalf("Pi(%q) = %v, want %v", home, got, wantPi)
+		}
+		if got := OMP(home); !slices.Equal(got, wantOMP) {
+			t.Fatalf("OMP(%q) = %v, want %v", home, got, wantOMP)
+		}
+	})
+
+	t.Run("independent list vars", func(t *testing.T) {
+		clearAllEnv(t)
+		home := t.TempDir()
+		t.Setenv(PiListEnv, "/pi-profile")
+		t.Setenv(OMPListEnv, "/omp-profile")
+		wantPi := []string{
+			filepath.Join("/pi-profile", "sessions"),
+			filepath.Join(home, ".pi", "agent", "sessions"),
+		}
+		wantOMP := []string{
+			filepath.Join("/omp-profile", "sessions"),
+			filepath.Join(home, ".omp", "agent", "sessions"),
+		}
+		if got := Pi(home); !slices.Equal(got, wantPi) {
+			t.Fatalf("Pi(%q) = %v, want %v (PiListEnv must not leak into OMP)", home, got, wantPi)
+		}
+		if got := OMP(home); !slices.Equal(got, wantOMP) {
+			t.Fatalf("OMP(%q) = %v, want %v (OMPListEnv must not leak into Pi)", home, got, wantOMP)
+		}
+	})
+}

--- a/internal/app/conversation_invariant_test.go
+++ b/internal/app/conversation_invariant_test.go
@@ -1,0 +1,197 @@
+package app
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/0cv/herdr-mobile-relay/internal/agentroots"
+	"github.com/0cv/herdr-mobile-relay/internal/conversation"
+	"github.com/0cv/herdr-mobile-relay/internal/session"
+)
+
+// The bug this package's conversation plumbing exists to avoid: the pane title
+// was read out of one directory tree while the transcript was looked up in
+// another, so the header showed a correct title next to "No conversation log is
+// available for this session."
+//
+// session.Resolver and conversation.Reader live in different packages and
+// neither can see the other's fields, so an assertion inside either package can
+// only restate its own construction. The invariant is a BEHAVIOURAL one and has
+// to be tested where both types meet, which is here: for the same agent, cwd and
+// session id, the title and the transcript must either both resolve or both
+// fail. Never one without the other.
+func writeClaudeTranscript(t *testing.T, path, title string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// The user prompt is a bare string, not a block array, on purpose. This file
+	// tests PATH RESOLUTION - which tree a transcript is found in - and must not
+	// depend on how Claude content shapes are parsed. A string prompt parses
+	// identically before and after the array-content fix, so these tests stay
+	// green at every commit in the series and can also be run against v0.17.5.
+	rows := []map[string]any{
+		{"type": "summary", "summary": title},
+		{"type": "user", "uuid": "u1", "timestamp": "2026-08-12T10:00:00Z",
+			"message": map[string]any{"content": "the prompt"}},
+		{"type": "assistant", "uuid": "a1", "timestamp": "2026-08-12T10:00:01Z",
+			"message": map[string]any{"content": []any{map[string]any{"type": "text", "text": "the answer"}}}},
+	}
+	var buf []byte
+	for _, row := range rows {
+		encoded, err := json.Marshal(row)
+		if err != nil {
+			t.Fatal(err)
+		}
+		buf = append(buf, encoded...)
+		buf = append(buf, '\n')
+	}
+	if err := os.WriteFile(path, buf, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func clearAgentEnv(t *testing.T) {
+	t.Helper()
+	for _, name := range []string{
+		"CLAUDE_CONFIG_DIR", "CODEX_HOME", "PI_CODING_AGENT_DIR",
+		agentroots.ClaudeListEnv, agentroots.QoderListEnv, agentroots.CodexListEnv,
+		agentroots.PiListEnv, agentroots.OMPListEnv,
+	} {
+		t.Setenv(name, "")
+	}
+}
+
+const invariantSession = "123e4567-e89b-12d3-a456-426614174321"
+
+// Both halves resolve for a session reachable only through a non-default
+// profile. Before the fix the title resolved and the transcript did not, which
+// is exactly the reported symptom.
+func TestTitleAndTranscriptAgreeForANonDefaultProfile(t *testing.T) {
+	clearAgentEnv(t)
+	home := t.TempDir()
+	profile := t.TempDir()
+	t.Setenv(agentroots.ClaudeListEnv, profile)
+
+	const cwd = "/work/app"
+	writeClaudeTranscript(t, filepath.Join(profile, "projects", "-work-app", invariantSession+".jsonl"), "Profile Title")
+
+	title := session.NewResolver(home).SessionName("claude", cwd, invariantSession)
+	page, err := conversation.NewReader(home).Read("claude", invariantSession, "", 80)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if title == "" {
+		t.Errorf("title did not resolve from the configured profile")
+	}
+	if !page.Available {
+		t.Errorf("transcript did not resolve from the configured profile: reason=%q", page.Reason)
+	}
+	if title != "" && !page.Available {
+		t.Fatalf("INVARIANT BROKEN: title %q resolved while the transcript reported %q", title, page.Reason)
+	}
+	if page.Available && page.Total != 2 {
+		t.Errorf("page total = %d, want the prompt and the answer", page.Total)
+	}
+}
+
+// The same agreement must hold for the home default with no configuration at
+// all, so the fix is a no-op for a single-profile install.
+func TestTitleAndTranscriptAgreeForTheHomeDefault(t *testing.T) {
+	clearAgentEnv(t)
+	home := t.TempDir()
+
+	const cwd = "/work/app"
+	writeClaudeTranscript(t, filepath.Join(home, ".claude", "projects", "-work-app", invariantSession+".jsonl"), "Home Title")
+
+	title := session.NewResolver(home).SessionName("claude", cwd, invariantSession)
+	page, err := conversation.NewReader(home).Read("claude", invariantSession, "", 80)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if title == "" || !page.Available {
+		t.Fatalf("INVARIANT BROKEN: title=%q available=%v reason=%q", title, page.Available, page.Reason)
+	}
+}
+
+// And they must fail TOGETHER when the session exists in no configured root,
+// with the reason string that distinguishes a path-resolution failure from a
+// missing session id. A title without a transcript here would be the original
+// bug reappearing.
+func TestTitleAndTranscriptFailTogetherWhenNoRootHasTheSession(t *testing.T) {
+	clearAgentEnv(t)
+	home := t.TempDir()
+	profile := t.TempDir()
+	t.Setenv(agentroots.ClaudeListEnv, profile)
+
+	// A project directory exists in both roots, but neither holds this session.
+	for _, root := range []string{filepath.Join(profile, "projects"), filepath.Join(home, ".claude", "projects")} {
+		if err := os.MkdirAll(filepath.Join(root, "-work-app"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	title := session.NewResolver(home).SessionName("claude", "/work/app", invariantSession)
+	page, err := conversation.NewReader(home).Read("claude", invariantSession, "", 80)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if title != "" {
+		t.Errorf("title = %q, want empty when no root holds the session", title)
+	}
+	if page.Available {
+		t.Errorf("transcript resolved from nowhere: %#v", page.Entries)
+	}
+	if page.Reason != "No conversation log is available for this session." {
+		t.Errorf("reason = %q, want the path-resolution reason verbatim", page.Reason)
+	}
+}
+
+// The exact production shape of the reported bug, written so it runs against
+// v0.17.5 too: the pane's agent used a non-default config directory, so the
+// relay's CLAUDE_CONFIG_DIR names a profile, while the transcript the title is
+// read from sits under ~/.claude. Before the fix the reader honoured
+// CLAUDE_CONFIG_DIR and searched only the profile while the resolver ignored it
+// and searched only ~/.claude, so the title resolved and the transcript did not.
+// This is the regression guard: it fails on v0.17.5 and passes here.
+func TestLegacyConfigDirDoesNotSplitTitleFromTranscript(t *testing.T) {
+	clearAgentEnv(t)
+	home := t.TempDir()
+	profile := t.TempDir()
+	t.Setenv("CLAUDE_CONFIG_DIR", profile)
+	if err := os.MkdirAll(filepath.Join(profile, "projects"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	writeClaudeTranscript(t, filepath.Join(home, ".claude", "projects", "-work-app", invariantSession+".jsonl"), "Home Title")
+
+	title := session.NewResolver(home).SessionName("claude", "/work/app", invariantSession)
+	page, err := conversation.NewReader(home).Read("claude", invariantSession, "", 80)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if title != "" && !page.Available {
+		t.Fatalf("INVARIANT BROKEN, the reported bug: title %q resolved while the transcript reported %q",
+			title, page.Reason)
+	}
+	if title == "" || !page.Available {
+		t.Fatalf("both halves should resolve: title=%q available=%v reason=%q", title, page.Available, page.Reason)
+	}
+}
+
+// A missing session id is a different failure from a path that cannot be
+// resolved, and the two reason strings are the only signal that tells an
+// operator which one happened. Pin both.
+func TestMissingSessionIDKeepsItsOwnReason(t *testing.T) {
+	clearAgentEnv(t)
+	page, err := conversation.NewReader(t.TempDir()).Read("claude", "", "", 80)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if page.Available || page.Reason != "This agent has not reported a conversation session yet." {
+		t.Fatalf("page = %#v, want the missing-session-id reason verbatim", page)
+	}
+}

--- a/internal/conversation/reader.go
+++ b/internal/conversation/reader.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"unicode/utf8"
 
+	"github.com/0cv/herdr-mobile-relay/internal/agentroots"
 	panehistory "github.com/0cv/herdr-mobile-relay/internal/history"
 )
 
@@ -62,23 +63,13 @@ type Reader struct {
 }
 
 func NewReader(home string) *Reader {
-	claudeHome := firstConfiguredRoot("CLAUDE_CONFIG_DIR", filepath.Join(home, ".claude"))
-	codexHome := firstConfiguredRoot("CODEX_HOME", filepath.Join(home, ".codex"))
-	piHome := firstConfiguredRoot("PI_CODING_AGENT_DIR", filepath.Join(home, ".pi", "agent"))
 	return &Reader{
-		claudeRoots: []string{filepath.Join(claudeHome, "projects")},
-		qoderRoots:  []string{filepath.Join(home, ".qoder", "projects")},
-		codexRoots:  []string{filepath.Join(codexHome, "sessions")},
-		piRoots:     []string{filepath.Join(piHome, "sessions")},
-		ompRoots:    []string{filepath.Join(home, ".omp", "agent", "sessions")},
+		claudeRoots: agentroots.Claude(home),
+		qoderRoots:  agentroots.Qoder(home),
+		codexRoots:  agentroots.Codex(home),
+		piRoots:     agentroots.Pi(home),
+		ompRoots:    agentroots.OMP(home),
 	}
-}
-
-func firstConfiguredRoot(environment, fallback string) string {
-	if configured := strings.TrimSpace(os.Getenv(environment)); configured != "" {
-		return configured
-	}
-	return fallback
 }
 
 func Supported(agent string) bool {

--- a/internal/conversation/reader_test.go
+++ b/internal/conversation/reader_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/0cv/herdr-mobile-relay/internal/agentroots"
 )
 
 const testSessionID = "123e4567-e89b-12d3-a456-426614174000"
@@ -15,6 +17,11 @@ func testReader(t *testing.T) (*Reader, string) {
 	t.Setenv("CLAUDE_CONFIG_DIR", "")
 	t.Setenv("CODEX_HOME", "")
 	t.Setenv("PI_CODING_AGENT_DIR", "")
+	t.Setenv(agentroots.ClaudeListEnv, "")
+	t.Setenv(agentroots.QoderListEnv, "")
+	t.Setenv(agentroots.CodexListEnv, "")
+	t.Setenv(agentroots.PiListEnv, "")
+	t.Setenv(agentroots.OMPListEnv, "")
 	home := t.TempDir()
 	return NewReader(home), home
 }
@@ -173,5 +180,103 @@ func TestClaudeConversationAssociatesToolResultsWithCallingTurn(t *testing.T) {
 		!strings.Contains(tool.Input, `"path":"README.md"`) ||
 		tool.Output != "file contents" || tool.Error {
 		t.Fatalf("tool = %#v", tool)
+	}
+}
+
+const secondSessionID = "223e4567-e89b-12d3-a456-426614174001"
+
+func TestClaudeConversationResolvesFromAdditionalConfiguredRoot(t *testing.T) {
+	_, home := testReader(t)
+	profileDir := t.TempDir()
+	t.Setenv(agentroots.ClaudeListEnv, profileDir)
+	reader := NewReader(home)
+
+	profilePath := filepath.Join(profileDir, "projects", "-work", testSessionID+".jsonl")
+	writeRows(t, profilePath,
+		map[string]any{"type": "user", "uuid": "u1", "timestamp": "2026-08-12T10:00:00Z", "message": map[string]any{"content": "from profile root"}},
+		map[string]any{"type": "assistant", "uuid": "a1", "timestamp": "2026-08-12T10:00:01Z", "message": map[string]any{"content": []any{map[string]any{"type": "text", "text": "profile answer"}}}},
+	)
+	profilePage, err := reader.Read("claude", testSessionID, "", 80)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !profilePage.Available || profilePage.Total != 2 ||
+		profilePage.Entries[0].Text != "from profile root" || profilePage.Entries[1].Text != "profile answer" {
+		t.Fatalf("profile page = %#v, want two entries resolved from the additional root", profilePage)
+	}
+
+	homePath := filepath.Join(home, ".claude", "projects", "-work2", secondSessionID+".jsonl")
+	writeRows(t, homePath,
+		map[string]any{"type": "user", "uuid": "u2", "timestamp": "2026-08-12T10:00:00Z", "message": map[string]any{"content": "from home root"}},
+	)
+	homePage, err := reader.Read("claude", secondSessionID, "", 80)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !homePage.Available || homePage.Total != 1 || homePage.Entries[0].Text != "from home root" {
+		t.Fatalf("home page = %#v, want the home-default root to still resolve alongside the configured list", homePage)
+	}
+}
+
+func TestClaudeConversationUnavailableWhenSessionMissingFromAllRoots(t *testing.T) {
+	reader, _ := testReader(t)
+	page, err := reader.Read("claude", testSessionID, "", 80)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if page.Available {
+		t.Fatalf("page = %#v, want unavailable", page)
+	}
+	if page.Reason != "No conversation log is available for this session." {
+		t.Fatalf("reason = %q", page.Reason)
+	}
+}
+
+func TestPiConversationConfinesReportedPathAcrossMultipleRoots(t *testing.T) {
+	_, home := testReader(t)
+	profileDir := t.TempDir()
+	t.Setenv(agentroots.PiListEnv, profileDir)
+	reader := NewReader(home)
+
+	external := filepath.Join(t.TempDir(), "outside.jsonl")
+	writeRows(t, external, map[string]any{"type": "message", "message": map[string]any{"role": "user", "content": "outside"}})
+
+	linkDir := filepath.Join(profileDir, "sessions", "--work--")
+	if err := os.MkdirAll(linkDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(linkDir, "linked.jsonl")
+	if err := os.Symlink(external, link); err != nil {
+		t.Fatal(err)
+	}
+
+	page, err := reader.Read("pi", link, "", 80)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if page.Available {
+		t.Fatal("symlink inside a configured root pointing outside every root was served")
+	}
+}
+
+func TestOMPConversationResolvesFromConfiguredProfileRoot(t *testing.T) {
+	_, home := testReader(t)
+	profileDir := t.TempDir()
+	t.Setenv(agentroots.OMPListEnv, profileDir)
+	reader := NewReader(home)
+
+	path := filepath.Join(profileDir, "sessions", "-work", "session_"+testSessionID+".jsonl")
+	writeRows(t, path,
+		map[string]any{"type": "message", "id": "u1", "timestamp": "2026-08-12T10:00:00Z", "message": map[string]any{"role": "user", "content": []any{map[string]any{"type": "text", "text": "question"}}}},
+		map[string]any{"type": "message", "id": "a1", "timestamp": "2026-08-12T10:00:01Z", "message": map[string]any{"role": "assistant", "content": []any{map[string]any{"type": "text", "text": "response"}}}},
+	)
+
+	page, err := reader.Read("omp", testSessionID, "", 80)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !page.Available || page.Total != 2 ||
+		page.Entries[0].Text != "question" || page.Entries[1].Text != "response" {
+		t.Fatalf("page = %#v, want the omp profile root to resolve", page)
 	}
 }

--- a/internal/profiles/resolver.go
+++ b/internal/profiles/resolver.go
@@ -37,13 +37,14 @@ var defaultAliases = map[string]string{
 	"pi-coding-agent": "pi",
 }
 
-var defaultSkillDirs = map[string][]string{
-	"pi": {"~/.pi/agent/skills"},
-}
+// defaultSkillDirs and defaultCommandFormats hold no defaults: every provider
+// discovers its own skill directories the way its agent does, and a default
+// format would make CommandConfig report every such profile as explicitly
+// configured, permanently routing it down the INI escape hatch. Both maps stay
+// because the INI [skills] and [commands] sections populate them at runtime.
+var defaultSkillDirs = map[string][]string{}
 
-var defaultCommandFormats = map[string]string{
-	"pi": "skill:{name}",
-}
+var defaultCommandFormats = map[string]string{}
 
 type IntegrationStatuser interface {
 	IntegrationStatus(ctx context.Context) ([]byte, error)

--- a/internal/profiles/resolver_test.go
+++ b/internal/profiles/resolver_test.go
@@ -198,17 +198,6 @@ func TestCommandConfig(t *testing.T) {
 	}
 }
 
-func TestDefaultCommandConfigExpandsHome(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	resolver := NewResolver(t.TempDir(), nil)
-	dirs, format, ok := resolver.CommandConfig("pi")
-	want := filepath.Join(home, ".pi", "agent", "skills")
-	if !ok || format != "skill:{name}" || len(dirs) != 1 || dirs[0] != want {
-		t.Fatalf("default command config = %q, %q, %v; want %q", dirs, format, ok, want)
-	}
-}
-
 func profileLabel(profiles []Profile, id string) string {
 	for _, profile := range profiles {
 		if profile.ID == id {

--- a/internal/session/resolver.go
+++ b/internal/session/resolver.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/0cv/herdr-mobile-relay/internal/agentroots"
 )
 
 const cacheTTL = 60 * time.Second
@@ -21,15 +23,26 @@ type cacheEntry struct {
 }
 
 type Resolver struct {
-	mu    sync.Mutex
-	cache map[string]cacheEntry
-	home  string
+	mu          sync.Mutex
+	cache       map[string]cacheEntry
+	claudeRoots []string
+	qoderRoots  []string
+	codexHomes  []string
+	piRoots     []string
+	ompRoots    []string
 }
 
+// NewResolver resolves every agent's roots once, through the same seam
+// conversation.NewReader uses, so a pane's title and its transcript can never
+// be looked up in different trees.
 func NewResolver(home string) *Resolver {
 	return &Resolver{
-		cache: make(map[string]cacheEntry),
-		home:  home,
+		cache:       make(map[string]cacheEntry),
+		claudeRoots: agentroots.Claude(home),
+		qoderRoots:  agentroots.Qoder(home),
+		codexHomes:  agentroots.CodexHomes(home),
+		piRoots:     agentroots.Pi(home),
+		ompRoots:    agentroots.OMP(home),
 	}
 }
 
@@ -68,9 +81,9 @@ func (r *Resolver) SessionName(agent, cwd, sessionID string) string {
 	case isPiSessionAgent(agentLower):
 		name = extractPiSessionTitle(sessionPath)
 	case strings.Contains(agentLower, "qoder"):
-		name = r.projectSessionTitle(filepath.Join(r.home, ".qoder", "projects"), cwd, sessionID)
+		name = r.projectSessionTitle(r.qoderRoots, cwd, sessionID)
 	case strings.Contains(agentLower, "claude"):
-		name = r.projectSessionTitle(filepath.Join(r.home, ".claude", "projects"), cwd, sessionID)
+		name = r.projectSessionTitle(r.claudeRoots, cwd, sessionID)
 	case strings.Contains(agentLower, "codex"):
 		name = r.codexSessionName(cwd, sessionID)
 	}
@@ -101,18 +114,22 @@ func isPiSessionAgent(agent string) bool {
 }
 
 func (r *Resolver) ompSessionPath(sessionID string) string {
+	return containedSessionFile(r.ompRoots, sessionID)
+}
+
+// containedSessionFile reports the resolved path of sessionID when it names a
+// regular .jsonl file inside at least one root. The predicates are the original
+// single-root check - IsAbs, .jsonl, Abs, EvalSymlinks, Rel, Mode().IsRegular()
+// - unchanged; the path-side ones are hoisted out of the loop because they do
+// not depend on the root, and every root-side bail-out becomes "try the next
+// root" so a root that fails to resolve is skipped rather than treated as a
+// match. Multi-root means contained in at least one root, never containment
+// skipped.
+func containedSessionFile(roots []string, sessionID string) string {
 	if !filepath.IsAbs(sessionID) || filepath.Ext(sessionID) != ".jsonl" {
 		return ""
 	}
-	root, err := filepath.Abs(filepath.Join(r.home, ".omp", "agent", "sessions"))
-	if err != nil {
-		return ""
-	}
 	path, err := filepath.Abs(filepath.Clean(sessionID))
-	if err != nil {
-		return ""
-	}
-	root, err = filepath.EvalSymlinks(root)
 	if err != nil {
 		return ""
 	}
@@ -120,15 +137,25 @@ func (r *Resolver) ompSessionPath(sessionID string) string {
 	if err != nil {
 		return ""
 	}
-	rel, err := filepath.Rel(root, path)
-	if err != nil || rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+	if info, err := os.Stat(path); err != nil || !info.Mode().IsRegular() {
 		return ""
 	}
-	info, err := os.Stat(path)
-	if err != nil || !info.Mode().IsRegular() {
-		return ""
+	for _, candidate := range roots {
+		root, err := filepath.Abs(candidate)
+		if err != nil {
+			continue
+		}
+		root, err = filepath.EvalSymlinks(root)
+		if err != nil {
+			continue
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil || rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			continue
+		}
+		return path
 	}
-	return path
+	return ""
 }
 
 func extractOMPSessionTitle(path string) string {
@@ -178,34 +205,7 @@ func extractOMPSessionTitle(path string) string {
 }
 
 func (r *Resolver) piSessionPath(sessionID string) string {
-	if !filepath.IsAbs(sessionID) || filepath.Ext(sessionID) != ".jsonl" {
-		return ""
-	}
-	root, err := filepath.Abs(filepath.Join(r.home, ".pi", "agent", "sessions"))
-	if err != nil {
-		return ""
-	}
-	path, err := filepath.Abs(filepath.Clean(sessionID))
-	if err != nil {
-		return ""
-	}
-	root, err = filepath.EvalSymlinks(root)
-	if err != nil {
-		return ""
-	}
-	path, err = filepath.EvalSymlinks(path)
-	if err != nil {
-		return ""
-	}
-	rel, err := filepath.Rel(root, path)
-	if err != nil || rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
-		return ""
-	}
-	info, err := os.Stat(path)
-	if err != nil || !info.Mode().IsRegular() {
-		return ""
-	}
-	return path
+	return containedSessionFile(r.piRoots, sessionID)
 }
 
 func extractPiSessionTitle(path string) string {
@@ -233,7 +233,19 @@ func extractPiSessionTitle(path string) string {
 	return name
 }
 
-func (r *Resolver) projectSessionTitle(projectsDir, cwd, sessionID string) string {
+// projectSessionTitle returns the first non-empty title across the agent's
+// roots. A root whose project directory exists but does not hold this session
+// must not end the search - the session may live in another profile.
+func (r *Resolver) projectSessionTitle(roots []string, cwd, sessionID string) string {
+	for _, projectsDir := range roots {
+		if title := r.projectTitleInRoot(projectsDir, cwd, sessionID); title != "" {
+			return title
+		}
+	}
+	return ""
+}
+
+func (r *Resolver) projectTitleInRoot(projectsDir, cwd, sessionID string) string {
 	projectDir := r.findProjectDir(projectsDir, cwd)
 	if projectDir == "" {
 		return ""
@@ -291,7 +303,15 @@ func (r *Resolver) findProjectDir(projectsDir, cwd string) string {
 }
 
 func (r *Resolver) codexSessionName(cwd, sessionID string) string {
-	indexFile := filepath.Join(r.home, ".codex", "session_index.jsonl")
+	for _, codexHome := range r.codexHomes {
+		if name := codexIndexThreadName(filepath.Join(codexHome, "session_index.jsonl"), sessionID); name != "" {
+			return name
+		}
+	}
+	return ""
+}
+
+func codexIndexThreadName(indexFile, sessionID string) string {
 	f, err := os.Open(indexFile)
 	if err != nil {
 		return ""
@@ -391,32 +411,62 @@ func (r *Resolver) sourceSignature(agent, cwd, sessionID string) string {
 	}
 
 	if strings.Contains(agentLower, "codex") {
-		return pathSignature(filepath.Join(r.home, ".codex", "session_index.jsonl"))
+		return rootsSignature(r.codexHomes, "session_index.jsonl")
 	}
-	var projectsDir string
+	var projectsRoots []string
 	switch {
 	case strings.Contains(agentLower, "qoder"):
-		projectsDir = filepath.Join(r.home, ".qoder", "projects")
+		projectsRoots = r.qoderRoots
 	case strings.Contains(agentLower, "claude"):
-		projectsDir = filepath.Join(r.home, ".claude", "projects")
+		projectsRoots = r.claudeRoots
 	default:
 		return ""
 	}
-	projectDir := r.findProjectDir(projectsDir, cwd)
-	if projectDir == "" {
-		return pathSignature(projectsDir)
-	}
-	if sessionID != "" {
-		return pathSignature(filepath.Join(projectDir, sessionID+".jsonl"))
-	}
-	entries, _ := os.ReadDir(projectDir)
-	var signatures []string
-	for _, entry := range entries {
-		if !entry.IsDir() && strings.HasSuffix(entry.Name(), ".jsonl") {
-			signatures = append(signatures, pathSignature(filepath.Join(projectDir, entry.Name())))
+	// Sign the candidate in EVERY root, never just the first root that happens
+	// to have a project directory for this cwd. projectSessionTitle keeps
+	// searching until a root yields a non-empty title, so stopping here at an
+	// earlier root would sign a file the title did not come from and pin a
+	// stale title for the whole cache TTL. With exactly one root - every
+	// default, unconfigured install - this reduces to the original signature.
+	signatures := make([]string, 0, len(projectsRoots))
+	for _, projectsDir := range projectsRoots {
+		projectDir := r.findProjectDir(projectsDir, cwd)
+		if projectDir == "" {
+			signatures = append(signatures, pathSignature(projectsDir))
+			continue
 		}
+		if sessionID != "" {
+			signatures = append(signatures, pathSignature(filepath.Join(projectDir, sessionID+".jsonl")))
+			continue
+		}
+		// With no session id the title falls back to the sole .jsonl in the
+		// directory, so the choice depends on the whole listing: a second file
+		// appearing must invalidate the cache.
+		entries, _ := os.ReadDir(projectDir)
+		listing := make([]string, 0, len(entries))
+		for _, entry := range entries {
+			if !entry.IsDir() && strings.HasSuffix(entry.Name(), ".jsonl") {
+				listing = append(listing, pathSignature(filepath.Join(projectDir, entry.Name())))
+			}
+		}
+		sort.Strings(listing)
+		signatures = append(signatures, strings.Join(listing, "|"))
 	}
-	sort.Strings(signatures)
+	return strings.Join(signatures, "|")
+}
+
+// rootsSignature signs one file per root (or the root itself when leaf is
+// empty), joined in root order. The root list is fixed when the Resolver is
+// built, so the result is deterministic.
+func rootsSignature(roots []string, leaf string) string {
+	signatures := make([]string, 0, len(roots))
+	for _, root := range roots {
+		path := root
+		if leaf != "" {
+			path = filepath.Join(root, leaf)
+		}
+		signatures = append(signatures, pathSignature(path))
+	}
 	return strings.Join(signatures, "|")
 }
 

--- a/internal/session/resolver_test.go
+++ b/internal/session/resolver_test.go
@@ -11,6 +11,31 @@ import (
 	"github.com/0cv/herdr-mobile-relay/internal/agentroots"
 )
 
+// TestMain clears every environment variable agentroots consults before any
+// test in this package runs. Without this, a developer's exported
+// CLAUDE_CONFIG_DIR / CODEX_HOME / PI_CODING_AGENT_DIR / HERDR_*_CONFIG_DIRS
+// leaks into every test's Resolver and can override the fixture data it just
+// wrote (see clearAgentRootEnv below for the per-test escape hatch used by
+// tests that need to reassert a var mid-run). A single TestMain protects every
+// test in the package, including ones added later that forget to call
+// clearAgentRootEnv themselves - the property the per-test helper alone
+// cannot guarantee.
+func TestMain(m *testing.M) {
+	for _, key := range []string{
+		agentroots.ClaudeListEnv,
+		agentroots.QoderListEnv,
+		agentroots.CodexListEnv,
+		agentroots.PiListEnv,
+		agentroots.OMPListEnv,
+		"CLAUDE_CONFIG_DIR",
+		"CODEX_HOME",
+		"PI_CODING_AGENT_DIR",
+	} {
+		os.Setenv(key, "")
+	}
+	os.Exit(m.Run())
+}
+
 func TestQoderSessionName(t *testing.T) {
 	home := t.TempDir()
 	projDir := filepath.Join(home, ".qoder", "projects", "home-user-myapp")

--- a/internal/session/resolver_test.go
+++ b/internal/session/resolver_test.go
@@ -455,3 +455,70 @@ func TestTitleCacheTracksTheRootTheTitleActuallyCameFrom(t *testing.T) {
 		t.Fatalf("second call = %q, want %q - the cache signed the wrong root", got, "Renamed Title")
 	}
 }
+
+// The two paths this change unified did not agree before it: the conversation
+// reader honoured CLAUDE_CONFIG_DIR and searched only that directory, while the
+// resolver ignored the variable and searched only ~/.claude. Neither old
+// behaviour can be reproduced byte-for-byte on both paths at once, because that
+// disagreement was the bug. What must hold instead is that the change only ever
+// WIDENS: every lookup that resolved at v0.17.5 still resolves, to the same
+// value. This test pins that for the legacy variable - the home default stays
+// searched (the old resolver behaviour) and the configured directory is now
+// searched too (the old reader behaviour), with the configured one taking
+// precedence in the order.
+func TestLegacyClaudeConfigDirWidensWithoutDroppingTheHomeDefault(t *testing.T) {
+	clearAgentRootEnv(t)
+	home := t.TempDir()
+	profile := t.TempDir()
+	t.Setenv("CLAUDE_CONFIG_DIR", profile)
+
+	writeTitleFile(t, filepath.Join(home, ".claude", "projects", "home-user-app", "sess-home.jsonl"), "Home Title")
+	writeTitleFile(t, filepath.Join(profile, "projects", "home-user-app", "sess-profile.jsonl"), "Profile Title")
+
+	r := NewResolver(home)
+	if got, want := r.claudeRoots, []string{
+		filepath.Join(profile, "projects"),
+		filepath.Join(home, ".claude", "projects"),
+	}; !slices.Equal(got, want) {
+		t.Fatalf("claudeRoots = %v, want the configured directory first then the home default %v", got, want)
+	}
+
+	// Old resolver behaviour: ~/.claude was always searched. Still true.
+	if got := r.SessionName("claude", "/home/user/app", "sess-home"); got != "Home Title" {
+		t.Errorf("home-default session title = %q, want %q - the home default must stay searched", got, "Home Title")
+	}
+	// Old reader behaviour: CLAUDE_CONFIG_DIR was honoured. Now titles honour it too.
+	if got := r.SessionName("claude", "/home/user/app", "sess-profile"); got != "Profile Title" {
+		t.Errorf("configured-directory session title = %q, want %q", got, "Profile Title")
+	}
+}
+
+// Same widening guarantee for the agents whose roots used to be hardcoded with
+// no override at all, and for Pi/OMP sharing PI_CODING_AGENT_DIR: setting the
+// legacy variable must not cost either agent its own home default.
+func TestLegacyPiCodingAgentDirKeepsBothHomeDefaults(t *testing.T) {
+	clearAgentRootEnv(t)
+	home := t.TempDir()
+	profile := t.TempDir()
+	t.Setenv("PI_CODING_AGENT_DIR", profile)
+
+	r := NewResolver(home)
+	for _, c := range []struct {
+		name string
+		got  []string
+		want []string
+	}{
+		{"piRoots", r.piRoots, []string{
+			filepath.Join(profile, "sessions"),
+			filepath.Join(home, ".pi", "agent", "sessions"),
+		}},
+		{"ompRoots", r.ompRoots, []string{
+			filepath.Join(profile, "sessions"),
+			filepath.Join(home, ".omp", "agent", "sessions"),
+		}},
+	} {
+		if !slices.Equal(c.got, c.want) {
+			t.Errorf("%s = %v, want %v", c.name, c.got, c.want)
+		}
+	}
+}

--- a/internal/session/resolver_test.go
+++ b/internal/session/resolver_test.go
@@ -4,7 +4,11 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"slices"
+	"strings"
 	"testing"
+
+	"github.com/0cv/herdr-mobile-relay/internal/agentroots"
 )
 
 func TestQoderSessionName(t *testing.T) {
@@ -221,5 +225,233 @@ func TestExactSessionIDDoesNotFallBackToOnlyOtherFile(t *testing.T) {
 	}
 	if got := NewResolver(home).SessionName("claude", "/home/user/app", "wanted"); got != "" {
 		t.Fatalf("session name = %q, want empty exact-ID miss", got)
+	}
+}
+
+// clearAgentRootEnv unsets every variable agentroots consults, so a developer's
+// exported shell environment cannot add roots to a test and make it flaky.
+func clearAgentRootEnv(t *testing.T) {
+	t.Helper()
+	for _, key := range []string{
+		agentroots.ClaudeListEnv,
+		agentroots.QoderListEnv,
+		agentroots.CodexListEnv,
+		agentroots.PiListEnv,
+		agentroots.OMPListEnv,
+		"CLAUDE_CONFIG_DIR",
+		"CODEX_HOME",
+		"PI_CODING_AGENT_DIR",
+	} {
+		t.Setenv(key, "")
+	}
+}
+
+func writeTitleFile(t *testing.T, path, title string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	data, err := json.Marshal(map[string]any{"type": "custom-title", "customTitle": title})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, append(data, '\n'), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Pins the architectural constraint whose absence produced the original bug:
+// NewResolver must take every root from the agentroots seam instead of
+// hand-rolling paths of its own. Reverting any field below to a
+// filepath.Join(r.home, ...) fails this, because the seam also carries the
+// configured list entry set up here.
+//
+// It deliberately does NOT claim to cover the title/transcript invariant.
+// Comparing this package's fields against the seam can only restate this
+// package's own construction, and conversation.Reader's roots are unexported
+// and live in another package. The behavioural half - title and transcript
+// resolving, or failing, together - is covered where both types are visible, in
+// internal/app/conversation_invariant_test.go. Keep the two in step.
+func TestResolverSourcesEveryRootFromTheSeam(t *testing.T) {
+	clearAgentRootEnv(t)
+	home := t.TempDir()
+	t.Setenv(agentroots.ClaudeListEnv, t.TempDir())
+
+	r := NewResolver(home)
+	for _, c := range []struct {
+		name string
+		got  []string
+		want []string
+	}{
+		{"claudeRoots", r.claudeRoots, agentroots.Claude(home)},
+		{"qoderRoots", r.qoderRoots, agentroots.Qoder(home)},
+		{"codexHomes", r.codexHomes, agentroots.CodexHomes(home)},
+		{"piRoots", r.piRoots, agentroots.Pi(home)},
+		{"ompRoots", r.ompRoots, agentroots.OMP(home)},
+	} {
+		if !slices.Equal(c.got, c.want) {
+			t.Errorf("%s = %v, want the seam's %v", c.name, c.got, c.want)
+		}
+	}
+}
+
+// A root whose project directory exists but does not hold this session must not
+// end the search: the session may live in another configured profile. Returning
+// "" from the first root fails this test.
+func TestClaudeTitleFromSecondRootWhenFirstRootLacksTheSession(t *testing.T) {
+	clearAgentRootEnv(t)
+	home := t.TempDir()
+	profile := t.TempDir()
+	t.Setenv(agentroots.ClaudeListEnv, profile)
+
+	writeTitleFile(t, filepath.Join(profile, "projects", "home-user-app", "unrelated.jsonl"), "First root title")
+	writeTitleFile(t, filepath.Join(home, ".claude", "projects", "home-user-app", "wanted.jsonl"), "Second root title")
+
+	r := NewResolver(home)
+	if len(r.claudeRoots) != 2 || r.claudeRoots[0] != filepath.Join(profile, "projects") {
+		t.Fatalf("claudeRoots = %v, want the configured profile first and the home default kept", r.claudeRoots)
+	}
+	if got := r.SessionName("claude", "/home/user/app", "wanted"); got != "Second root title" {
+		t.Fatalf("session name = %q, want %q", got, "Second root title")
+	}
+}
+
+func TestOMPSessionPathAcceptedFromNonDefaultRoot(t *testing.T) {
+	clearAgentRootEnv(t)
+	home := t.TempDir()
+	profile := t.TempDir()
+	t.Setenv(agentroots.OMPListEnv, profile)
+
+	sessionPath := filepath.Join(profile, "sessions", "-home-user-app", "s.jsonl")
+	if err := os.MkdirAll(filepath.Dir(sessionPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(sessionPath, []byte("{\"type\":\"title\",\"title\":\"profile_omp\"}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := NewResolver(home).SessionName("omp", "/home/user/app", sessionPath); got != "profile_omp" {
+		t.Fatalf("session name = %q, want %q", got, "profile_omp")
+	}
+}
+
+// Containment regression guard: a path outside every configured root is
+// rejected even though one configured root resolves fine.
+func TestOMPSessionPathRejectedOutsideEveryRoot(t *testing.T) {
+	clearAgentRootEnv(t)
+	home := t.TempDir()
+	profile := t.TempDir()
+	outside := t.TempDir()
+	t.Setenv(agentroots.OMPListEnv, profile)
+
+	if err := os.MkdirAll(filepath.Join(profile, "sessions"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	outsidePath := filepath.Join(outside, "escaped.jsonl")
+	if err := os.WriteFile(outsidePath, []byte("{\"type\":\"title\",\"title\":\"escaped_title\"}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := NewResolver(home).SessionName("omp", "/home/user/app", outsidePath); got != "" {
+		t.Fatalf("session name = %q, want empty for a path outside every root", got)
+	}
+}
+
+// Containment regression guard: a symlink sitting inside a configured root but
+// resolving outside every root is rejected, because the check evaluates
+// symlinks before comparing.
+func TestOMPSessionPathRejectedSymlinkEscapingEveryRoot(t *testing.T) {
+	clearAgentRootEnv(t)
+	home := t.TempDir()
+	profile := t.TempDir()
+	outside := t.TempDir()
+	t.Setenv(agentroots.OMPListEnv, profile)
+
+	target := filepath.Join(outside, "escaped.jsonl")
+	if err := os.WriteFile(target, []byte("{\"type\":\"title\",\"title\":\"escaped_title\"}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(profile, "sessions", "-home-user-app", "link.jsonl")
+	if err := os.MkdirAll(filepath.Dir(link), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := NewResolver(home).SessionName("omp", "/home/user/app", link); got != "" {
+		t.Fatalf("session name = %q, want empty for a symlink escaping every root", got)
+	}
+}
+
+func TestCodexTitleFromSecondConfiguredHome(t *testing.T) {
+	clearAgentRootEnv(t)
+	home := t.TempDir()
+	first := t.TempDir()
+	second := t.TempDir()
+	t.Setenv(agentroots.CodexListEnv, strings.Join([]string{first, second}, string(filepath.ListSeparator)))
+
+	data, err := json.Marshal(map[string]any{"id": "sess-second", "thread_name": "Second home thread"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(second, "session_index.jsonl"), append(data, '\n'), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := NewResolver(home).SessionName("codex", "/tmp", "sess-second"); got != "Second home thread" {
+		t.Fatalf("session name = %q, want %q; the first home has no index file and must not end the search", got, "Second home thread")
+	}
+}
+
+// Mirrors TestCacheTTL, but for a session reachable only through a non-default
+// root: sourceSignature has to sign the file the title actually came from.
+func TestCacheInvalidationWithNonDefaultClaudeRoot(t *testing.T) {
+	clearAgentRootEnv(t)
+	home := t.TempDir()
+	profile := t.TempDir()
+	t.Setenv(agentroots.ClaudeListEnv, profile)
+
+	sessionFile := filepath.Join(profile, "projects", "home-user-proj", "s1.jsonl")
+	writeTitleFile(t, sessionFile, "First Title")
+
+	r := NewResolver(home)
+	if got := r.SessionName("claude", "/home/user/proj", "s1"); got != "First Title" {
+		t.Fatalf("first call = %q, want %q", got, "First Title")
+	}
+
+	writeTitleFile(t, sessionFile, "Second Title After Rename")
+	if got := r.SessionName("claude", "/home/user/proj", "s1"); got != "Second Title After Rename" {
+		t.Fatalf("refreshed call = %q, want %q", got, "Second Title After Rename")
+	}
+}
+
+// Regression guard for the title cache. projectSessionTitle keeps searching
+// roots until one yields a non-empty title, so sourceSignature must sign the
+// candidate in EVERY root. Signing only the first root that happens to have a
+// project directory for this cwd - which it did - signs a file the title never
+// came from, and the cached title then survives an edit to the file it really
+// came from for the whole 60s TTL.
+func TestTitleCacheTracksTheRootTheTitleActuallyCameFrom(t *testing.T) {
+	clearAgentRootEnv(t)
+	home := t.TempDir()
+	first := t.TempDir()
+	second := t.TempDir()
+	t.Setenv(agentroots.ClaudeListEnv, first+string(os.PathListSeparator)+second)
+
+	// The first root has a project directory for this cwd but NOT this session,
+	// so the title has to come from the second root.
+	writeTitleFile(t, filepath.Join(first, "projects", "home-user-app", "other.jsonl"), "Unrelated")
+	target := filepath.Join(second, "projects", "home-user-app", "wanted.jsonl")
+	writeTitleFile(t, target, "First Title")
+
+	r := NewResolver(home)
+	if got := r.SessionName("claude", "/home/user/app", "wanted"); got != "First Title" {
+		t.Fatalf("first call = %q, want %q from the second root", got, "First Title")
+	}
+
+	writeTitleFile(t, target, "Renamed Title")
+	if got := r.SessionName("claude", "/home/user/app", "wanted"); got != "Renamed Title" {
+		t.Fatalf("second call = %q, want %q - the cache signed the wrong root", got, "Renamed Title")
 	}
 }

--- a/internal/slashcmd/claude.go
+++ b/internal/slashcmd/claude.go
@@ -87,7 +87,7 @@ func (p *claudeProvider) Discover(ctx DiscoverContext) ([]Command, bool) {
 	apply(claudeBuiltins, nil)
 
 	if ctx.Cwd != "" {
-		projectDirs := findClaudeProjectDirs(ctx.Cwd)
+		projectDirs := findProjectDirs(ctx.Cwd, []string{".claude"})
 		for _, dir := range projectDirs {
 			cmdDir := filepath.Join(dir, "commands")
 			cmds, supp, trunc := walkCommandDirBudget(cmdDir, "project", &budget)
@@ -142,7 +142,7 @@ func claudeSkillOverrides(ctx DiscoverContext) []string {
 		filepath.Join(ctx.Home, ".claude", "settings.json"),
 	}
 	if ctx.Cwd != "" {
-		for _, dir := range findClaudeProjectDirs(ctx.Cwd) {
+		for _, dir := range findProjectDirs(ctx.Cwd, []string{".claude"}) {
 			paths = append(paths,
 				filepath.Join(dir, "settings.json"),
 				filepath.Join(dir, "settings.local.json"),
@@ -241,52 +241,6 @@ func dedupClaudePrecedence(commands []Command, builtinCount, personalCount int, 
 		}
 	}
 	return result
-}
-
-// findClaudeProjectDirs returns all .claude directories from git root through cwd.
-// Without a git root, only cwd/.claude is checked.
-func findClaudeProjectDirs(cwd string) []string {
-	var dirs []string
-	seen := make(map[string]bool)
-
-	gitRoot := findGitRoot(cwd)
-	if gitRoot == "" {
-		candidate := filepath.Join(cwd, ".claude")
-		if info, err := os.Stat(candidate); err == nil && info.IsDir() {
-			dirs = append(dirs, candidate)
-		}
-		return dirs
-	}
-
-	candidate := filepath.Join(gitRoot, ".claude")
-	if info, err := os.Stat(candidate); err == nil && info.IsDir() {
-		dirs = append(dirs, candidate)
-		seen[candidate] = true
-	}
-
-	// Walk from cwd upward to git root, collecting .claude dirs.
-	var chain []string
-	dir := cwd
-	for depth := 0; depth < maxGitWalkDepth; depth++ {
-		candidate := filepath.Join(dir, ".claude")
-		if info, err := os.Stat(candidate); err == nil && info.IsDir() && !seen[candidate] {
-			chain = append(chain, candidate)
-			seen[candidate] = true
-		}
-		if dir == gitRoot {
-			break
-		}
-		parent := filepath.Dir(dir)
-		if parent == dir {
-			break
-		}
-		dir = parent
-	}
-	// Reverse chain so outermost scope comes first (git root direction).
-	for i := len(chain) - 1; i >= 0; i-- {
-		dirs = append(dirs, chain[i])
-	}
-	return dirs
 }
 
 func init() {

--- a/internal/slashcmd/frontmatter.go
+++ b/internal/slashcmd/frontmatter.go
@@ -14,7 +14,8 @@ func parseFrontmatterBytes(data []byte) (map[string]string, bool) {
 		return map[string]string{}, true
 	}
 	result := make(map[string]string)
-	for _, line := range lines[1:] {
+	for i := 1; i < len(lines); i++ {
+		line := lines[i]
 		if strings.TrimSpace(line) == "---" {
 			return result, true
 		}
@@ -24,12 +25,91 @@ func parseFrontmatterBytes(data []byte) (map[string]string, bool) {
 		}
 		key := strings.ToLower(matches[1])
 		value := matches[2]
-		if len(value) >= 2 && value[0] == value[len(value)-1] && (value[0] == '\'' || value[0] == '"') {
+		if folded, isBlock := blockScalarHeader(value); isBlock {
+			consumed := 0
+			value, consumed = foldBlockScalar(lines[i+1:], folded)
+			i += consumed
+		} else if len(value) >= 2 && value[0] == value[len(value)-1] && (value[0] == '\'' || value[0] == '"') {
 			value = value[1 : len(value)-1]
 		}
 		result[key] = value
 	}
 	return result, true
+}
+
+// blockScalarHeader reports whether value is a YAML block-scalar header such as
+// "|", "|-", ">-" or "|2+", and whether that header selects the folded style.
+// The indentation indicator is accepted but ignored: foldBlockScalar always
+// strips the block's own common indentation instead. Anything else - including a
+// plain scalar that merely starts with a pipe - is not a header.
+func blockScalarHeader(value string) (folded, ok bool) {
+	if value == "" {
+		return false, false
+	}
+	switch value[0] {
+	case '|':
+	case '>':
+		folded = true
+	default:
+		return false, false
+	}
+	for _, r := range value[1:] {
+		if r != '+' && r != '-' && (r < '1' || r > '9') {
+			return false, false
+		}
+	}
+	return folded, true
+}
+
+// foldBlockScalar joins the indented continuation lines of one block scalar and
+// returns the value plus the number of lines it consumed. The common indentation
+// is stripped, deeper relative indentation is preserved, literal blocks keep
+// their line breaks and folded blocks join lines with a space. The block ends at
+// the first non-empty line that is not indented past the key, at a "---" fence,
+// or at the end of the input; a block with no continuation lines yields "", so a
+// malformed one drops the skill rather than surfacing a bogus description.
+//
+// Chomping indicators are deliberately not honoured: every consumer runs the
+// value through compact, which collapses all whitespace runs anyway.
+func foldBlockScalar(rest []string, folded bool) (string, int) {
+	indent := -1
+	consumed := 0
+	var parts []string
+	for _, line := range rest {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "---" {
+			break
+		}
+		lineIndent := len(line) - len(strings.TrimLeft(line, " \t"))
+		if trimmed != "" && lineIndent == 0 {
+			break
+		}
+		consumed++
+		if trimmed == "" {
+			parts = append(parts, "")
+			continue
+		}
+		if indent < 0 || lineIndent < indent {
+			indent = lineIndent
+		}
+		parts = append(parts, line)
+	}
+	for len(parts) > 0 && parts[len(parts)-1] == "" {
+		parts = parts[:len(parts)-1]
+	}
+	if len(parts) == 0 {
+		return "", consumed
+	}
+	for i, part := range parts {
+		if part != "" {
+			parts[i] = part[indent:]
+		}
+	}
+	separator := "\n"
+	if folded {
+		separator = " "
+	}
+	return strings.Join(parts, separator), consumed
 }
 
 func readSkillMetadata(path string) (map[string]string, bool) {

--- a/internal/slashcmd/frontmatter_test.go
+++ b/internal/slashcmd/frontmatter_test.go
@@ -118,3 +118,180 @@ func TestReadSkillMetadataOversized(t *testing.T) {
 		t.Error("oversized file should return false")
 	}
 }
+
+// TestFrontmatterLiteralBlockScalar pins the real-world shape that used to yield
+// the literal description "|" in the palette.
+func TestFrontmatterLiteralBlockScalar(t *testing.T) {
+	data := []byte(`---
+name: archon
+description: |
+  Use when: User wants to run Archon workflows.
+  Triggers: "use archon to", "run archon".
+argument-hint: "[workflow] [message]"
+---
+Body text that must not leak into the description.
+`)
+	fm, ok := parseFrontmatterBytes(data)
+	if !ok {
+		t.Fatal("expected ok")
+	}
+	if fm["description"] == "|" {
+		t.Fatal(`description = "|": block scalar header was taken as the value`)
+	}
+	want := "Use when: User wants to run Archon workflows.\nTriggers: \"use archon to\", \"run archon\"."
+	if fm["description"] != want {
+		t.Errorf("description = %q, want %q", fm["description"], want)
+	}
+	wantCompact := `Use when: User wants to run Archon workflows. Triggers: "use archon to", "run archon".`
+	if got := compact(fm["description"], 240); got != wantCompact {
+		t.Errorf("compact(description) = %q, want %q", got, wantCompact)
+	}
+	if fm["name"] != "archon" {
+		t.Errorf("name = %q", fm["name"])
+	}
+	if fm["argument-hint"] != "[workflow] [message]" {
+		t.Errorf("argument-hint = %q: key after the block was not parsed", fm["argument-hint"])
+	}
+}
+
+func TestFrontmatterFoldedBlockScalar(t *testing.T) {
+	data := []byte(`---
+name: manage-run
+description: >-
+  Use when: User wants to INSPECT runs
+  driven through the archon CLI.
+---
+`)
+	fm, ok := parseFrontmatterBytes(data)
+	if !ok {
+		t.Fatal("expected ok")
+	}
+	if fm["description"] == ">-" {
+		t.Fatal(`description = ">-": block scalar header was taken as the value`)
+	}
+	want := "Use when: User wants to INSPECT runs driven through the archon CLI."
+	if fm["description"] != want {
+		t.Errorf("description = %q, want %q", fm["description"], want)
+	}
+}
+
+func TestFrontmatterBlockScalarHeaderVariants(t *testing.T) {
+	cases := []struct {
+		header string
+		want   string
+	}{
+		{"|", "alpha\nbeta"},
+		{"|-", "alpha\nbeta"},
+		{"|+", "alpha\nbeta"},
+		{"|2-", "alpha\nbeta"},
+		{">", "alpha beta"},
+		{">-", "alpha beta"},
+		{">+", "alpha beta"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.header, func(t *testing.T) {
+			data := []byte("---\ndescription: " + tc.header + "\n  alpha\n  beta\n---\n")
+			fm, ok := parseFrontmatterBytes(data)
+			if !ok {
+				t.Fatal("expected ok")
+			}
+			if fm["description"] != tc.want {
+				t.Errorf("description = %q, want %q", fm["description"], tc.want)
+			}
+		})
+	}
+}
+
+func TestFrontmatterBlockScalarKeepsRelativeIndent(t *testing.T) {
+	data := []byte("---\ndescription: |\n  line one\n    indented two\n  line three\n---\n")
+	fm, _ := parseFrontmatterBytes(data)
+	want := "line one\n  indented two\nline three"
+	if fm["description"] != want {
+		t.Errorf("description = %q, want %q", fm["description"], want)
+	}
+}
+
+func TestFrontmatterBlockScalarKeepsBlankLines(t *testing.T) {
+	data := []byte("---\ndescription: |\n  para one\n\n  para two\n\n---\n")
+	fm, _ := parseFrontmatterBytes(data)
+	want := "para one\n\npara two"
+	if fm["description"] != want {
+		t.Errorf("description = %q, want %q", fm["description"], want)
+	}
+}
+
+func TestFrontmatterBlockScalarEndsAtNextKey(t *testing.T) {
+	data := []byte("---\ndescription: |\n  first line\nname: after-block\n---\n")
+	fm, _ := parseFrontmatterBytes(data)
+	if fm["description"] != "first line" {
+		t.Errorf("description = %q", fm["description"])
+	}
+	if fm["name"] != "after-block" {
+		t.Errorf("name = %q: block swallowed the following key", fm["name"])
+	}
+}
+
+func TestFrontmatterBlockScalarEndsAtFence(t *testing.T) {
+	data := []byte("---\ndescription: |\n  first line\n---\nother: body line\n")
+	fm, _ := parseFrontmatterBytes(data)
+	if fm["description"] != "first line" {
+		t.Errorf("description = %q", fm["description"])
+	}
+	if _, exists := fm["other"]; exists {
+		t.Errorf("body key leaked into frontmatter: %v", fm)
+	}
+}
+
+// TestFrontmatterEmptyBlockScalarFailsOpen covers the malformed case: an empty
+// description drops the skill, which is safer than a one-character bogus one.
+func TestFrontmatterEmptyBlockScalarFailsOpen(t *testing.T) {
+	for _, data := range [][]byte{
+		[]byte("---\nname: broken\ndescription: |\n---\n"),
+		[]byte("---\nname: broken\ndescription: >-\n"),
+		[]byte("---\nname: broken\ndescription: |\nother: value\n---\n"),
+	} {
+		fm, ok := parseFrontmatterBytes(data)
+		if !ok {
+			t.Fatalf("expected ok for %q", data)
+		}
+		if fm["description"] != "" {
+			t.Errorf("description = %q for %q, want empty", fm["description"], data)
+		}
+	}
+}
+
+func TestFrontmatterPlainScalarStartingWithPipe(t *testing.T) {
+	data := []byte("---\ndescription: |not-a-header\nname: keeps-parsing\n---\n")
+	fm, _ := parseFrontmatterBytes(data)
+	if fm["description"] != "|not-a-header" {
+		t.Errorf("description = %q, want the plain scalar verbatim", fm["description"])
+	}
+	if fm["name"] != "keeps-parsing" {
+		t.Errorf("name = %q", fm["name"])
+	}
+}
+
+func TestReadSkillMetadataBlockScalarFromFile(t *testing.T) {
+	dir := t.TempDir()
+	path := dir + "/SKILL.md"
+	writeTestFile(t, path, "---\nname: deploy\ndescription: |\n  Ship the app\n  to production.\n---\nbody\n")
+
+	fm, ok := readSkillMetadata(path)
+	if !ok {
+		t.Fatal("expected ok")
+	}
+	if got := compact(fm["description"], 240); got != "Ship the app to production." {
+		t.Errorf("description = %q", got)
+	}
+}
+
+func TestReadSkillMetadataOversizedBlockScalar(t *testing.T) {
+	dir := t.TempDir()
+	path := dir + "/SKILL.md"
+	body := strings.Repeat("  filler line\n", maxMetadataSize/8)
+	writeTestFile(t, path, "---\nname: huge\ndescription: |\n"+body+"---\n")
+
+	if _, ok := readSkillMetadata(path); ok {
+		t.Error("oversized block scalar should still be rejected by maxMetadataSize")
+	}
+}

--- a/internal/slashcmd/kimi.go
+++ b/internal/slashcmd/kimi.go
@@ -1,5 +1,10 @@
 package slashcmd
 
+import (
+	"os"
+	"path/filepath"
+)
+
 // kimiBuiltins mirrors the primary interactive TUI commands in Kimi Code
 // 0.29.2. AgentVersion is available in DiscoverContext for a clean version
 // cutover when the command registry changes.
@@ -49,10 +54,142 @@ type kimiProvider struct{}
 
 func (p *kimiProvider) ID() string { return "kimi" }
 
-func (p *kimiProvider) Discover(_ DiscoverContext) ([]Command, bool) {
-	commands := make([]Command, len(kimiBuiltins))
-	copy(commands, kimiBuiltins)
-	return commands, false
+// Discover reproduces Kimi Code's own skill resolution, verified against
+// MoonshotAI/kimi-cli docs/en/customization/skills.md: the brand and generic
+// candidate groups at user and project scope plus the additive
+// extra_skill_dirs, rendered as the /skill:<name> commands Kimi registers. Kimi
+// also accepts a /<name> shorthand for the same skill; only the canonical form
+// is listed.
+//
+// Sources are scanned in descending Kimi precedence - Project > User > Extra -
+// with first-wins dedupe, and within one scope the brand group before the
+// generic group, because a name defined in both groups resolves to the brand
+// copy. Scanning the winners first also spends the shared file budget on them,
+// so exhaustion truncates the least important skills, never the winners.
+//
+// merge_all_available_skills governs the brand group only: the generic group is
+// always mutually exclusive, taking its first existing candidate.
+func (p *kimiProvider) Discover(ctx DiscoverContext) ([]Command, bool) {
+	if ctx.CommandFormat != "" {
+		// The relay's INI configured this profile explicitly, which outranks
+		// discovery.
+		custom, truncated := discoverGenericSkills(ctx.SkillDirs, ctx.CommandFormat)
+		return builtinsWithCustom(kimiBuiltins, custom), truncated
+	}
+
+	settings := defaultKimiSkillSettings()
+	if data, ok := readSettingsFile(filepath.Join(ctx.Home, ".kimi"), "config.toml"); ok {
+		parseKimiSkillSettings(data, &settings)
+	}
+
+	truncated := false
+	budget := maxCustomFiles
+	active := make(map[string]Command, len(kimiBuiltins))
+	order := make([]string, 0, len(kimiBuiltins))
+	apply := func(commands []Command) {
+		for _, command := range commands {
+			if _, exists := active[command.Command]; exists {
+				continue
+			}
+			order = append(order, command.Command)
+			active[command.Command] = command
+		}
+	}
+	apply(kimiBuiltins)
+
+	scan := func(scope string, dirs ...string) {
+		for _, dir := range dirs {
+			if dir == "" {
+				continue
+			}
+			cmds, trunc := scanSkillDirFormat(dir, scope, ompCommandFormat, &budget)
+			apply(cmds)
+			truncated = truncated || trunc
+		}
+	}
+	// firstExisting applies only the first candidate directory that exists. This
+	// is what a mutually exclusive group does: always for the generic group, and
+	// for the brand group when merge_all_available_skills is false.
+	firstExisting := func(scope string, candidates []string) {
+		for _, dir := range candidates {
+			if info, err := os.Stat(dir); err == nil && info.IsDir() {
+				scan(scope, dir)
+				return
+			}
+		}
+	}
+	// brandGroup applies a candidate group in Kimi's documented priority order,
+	// highest first: under first-wins the highest-priority directory registers
+	// a name first, and the budget is spent there first.
+	brandGroup := func(scope string, candidates []string) {
+		if !settings.mergeAllAvailableSkills {
+			firstExisting(scope, candidates)
+			return
+		}
+		for _, dir := range candidates {
+			scan(scope, dir)
+		}
+	}
+
+	// projectRoot is Kimi's project scope: the nearest .git ancestor of the work
+	// directory, falling back to the work directory itself. Kimi resolves every
+	// project candidate against it, so an intermediate ancestor between the work
+	// directory and the project root contributes nothing.
+	projectRoot := findGitRoot(ctx.Cwd)
+	if projectRoot == "" {
+		projectRoot = ctx.Cwd
+	}
+	projectSkillDirs := func(stems ...string) []string {
+		if projectRoot == "" {
+			return nil
+		}
+		dirs := make([]string, 0, len(stems))
+		for _, stem := range stems {
+			dirs = append(dirs, filepath.Join(projectRoot, stem, "skills"))
+		}
+		return dirs
+	}
+
+	// 1. project brand group (kimi > claude > codex), then 2. project generic
+	// group.
+	brandGroup("project", projectSkillDirs(".kimi", ".claude", ".codex"))
+	firstExisting("project", projectSkillDirs(".agents"))
+
+	// 3. user brand group, then 4. user generic group.
+	brandGroup("personal", []string{
+		filepath.Join(ctx.Home, ".kimi", "skills"),
+		filepath.Join(ctx.Home, ".claude", "skills"),
+		filepath.Join(ctx.Home, ".codex", "skills"),
+	})
+	firstExisting("personal", []string{
+		filepath.Join(ctx.Home, ".config", "agents", "skills"),
+		filepath.Join(ctx.Home, ".agents", "skills"),
+	})
+
+	// 5. extra_skill_dirs are additive user scope, scanned last: a brand or
+	// generic copy of the same name wins the collision. "~" resolves against
+	// home and a relative entry against the project root, as Kimi documents.
+	for _, dir := range settings.extraSkillDirs {
+		dir = expandTilde(dir, ctx.Home)
+		if !filepath.IsAbs(dir) {
+			if projectRoot == "" {
+				continue
+			}
+			dir = filepath.Join(projectRoot, dir)
+		}
+		scan("personal", dir)
+	}
+
+	commands := make([]Command, 0, len(order))
+	for _, name := range order {
+		if command, exists := active[name]; exists {
+			commands = append(commands, command)
+		}
+	}
+	if budget <= 0 {
+		truncated = true
+	}
+	return commands, truncated
 }
 
 func init() { registerProvider(&kimiProvider{}) }

--- a/internal/slashcmd/kimi_test.go
+++ b/internal/slashcmd/kimi_test.go
@@ -1,9 +1,14 @@
 package slashcmd
 
-import "testing"
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+)
 
 func TestKimiBuiltinCatalog(t *testing.T) {
-	catalog := CatalogForProfile("kimi", "kimi", "/tmp", "/nonexistent", nil, "", "0.29.2")
+	isolateAgentEnv(t)
+	catalog := CatalogForProfile("kimi", "kimi", t.TempDir(), "/nonexistent", nil, "", "0.29.2")
 	if catalog.Truncated {
 		t.Fatal("Kimi builtins should not be truncated")
 	}
@@ -18,7 +23,8 @@ func TestKimiBuiltinCatalog(t *testing.T) {
 }
 
 func TestKimiCommandHints(t *testing.T) {
-	catalog := CatalogFor("kimi-code", "/tmp", "/nonexistent")
+	isolateAgentEnv(t)
+	catalog := CatalogFor("kimi-code", t.TempDir(), "/nonexistent")
 	for _, command := range catalog.Commands {
 		if command.Command != "/goal" {
 			continue
@@ -29,4 +35,466 @@ func TestKimiCommandHints(t *testing.T) {
 		return
 	}
 	t.Fatal("/goal not found")
+}
+
+func TestParseKimiSkillSettings(t *testing.T) {
+	cases := []struct {
+		name      string
+		seedDirs  []string
+		data      string
+		wantMerge bool
+		wantDirs  []string
+	}{
+		{
+			name:      "bare false",
+			data:      "merge_all_available_skills = false\n",
+			wantMerge: false,
+		},
+		{
+			name:      "bare true",
+			data:      "merge_all_available_skills = true\n",
+			wantMerge: true,
+		},
+		{
+			name:      "case insensitive",
+			data:      "merge_all_available_skills = FALSE\n",
+			wantMerge: false,
+		},
+		{
+			name:      "quoted boolean",
+			data:      "merge_all_available_skills = \"false\"\n",
+			wantMerge: false,
+		},
+		{
+			name:      "unrecognised scalar leaves default",
+			data:      "merge_all_available_skills = 0\n",
+			wantMerge: true,
+		},
+		{
+			name:      "trailing comment stripped",
+			data:      "merge_all_available_skills = false # keep the old behaviour\n",
+			wantMerge: false,
+		},
+		{
+			name:      "comment line ignored",
+			data:      "# merge_all_available_skills = false\n",
+			wantMerge: true,
+		},
+		{
+			name:      "indented key still parsed",
+			data:      "  merge_all_available_skills = false\n",
+			wantMerge: false,
+		},
+		{
+			name:      "single line array",
+			data:      "extra_skill_dirs = [\"~/a\", '/b/c']\n",
+			wantMerge: true,
+			wantDirs:  []string{"~/a", "/b/c"},
+		},
+		{
+			name:      "array with trailing comment",
+			data:      "extra_skill_dirs = [\"~/a\"] # team shared\n",
+			wantMerge: true,
+			wantDirs:  []string{"~/a"},
+		},
+		{
+			name:      "hash inside a quoted item survives",
+			data:      "extra_skill_dirs = [\"~/a#b\"]\n",
+			wantMerge: true,
+			wantDirs:  []string{"~/a#b"},
+		},
+		{
+			name:      "empty items dropped",
+			data:      "extra_skill_dirs = [\"\", \"~/a\", ]\n",
+			wantMerge: true,
+			wantDirs:  []string{"~/a"},
+		},
+		{
+			name:      "empty array clears the key",
+			seedDirs:  []string{"~/keep"},
+			data:      "extra_skill_dirs = []\n",
+			wantMerge: true,
+			wantDirs:  nil,
+		},
+		{
+			name:      "multi line array leaves the key untouched",
+			seedDirs:  []string{"~/keep"},
+			data:      "extra_skill_dirs = [\n  \"~/a\",\n]\n",
+			wantMerge: true,
+			wantDirs:  []string{"~/keep"},
+		},
+		{
+			name:      "later file replaces the list",
+			seedDirs:  []string{"~/keep"},
+			data:      "extra_skill_dirs = [\"~/a\"]\n",
+			wantMerge: true,
+			wantDirs:  []string{"~/a"},
+		},
+		{
+			name:      "table header isolates a later key",
+			data:      "extra_skill_dirs = [\"~/a\"]\n\n[agent]\nmerge_all_available_skills = false\n",
+			wantMerge: true,
+			wantDirs:  []string{"~/a"},
+		},
+		{
+			name:      "root keys before a table header are consumed",
+			data:      "merge_all_available_skills = false\n[tui]\ntheme = \"dark\"\n",
+			wantMerge: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			settings := defaultKimiSkillSettings()
+			settings.extraSkillDirs = tc.seedDirs
+			parseKimiSkillSettings([]byte(tc.data), &settings)
+
+			if settings.mergeAllAvailableSkills != tc.wantMerge {
+				t.Errorf("mergeAllAvailableSkills = %v, want %v",
+					settings.mergeAllAvailableSkills, tc.wantMerge)
+			}
+			if len(settings.extraSkillDirs) != len(tc.wantDirs) {
+				t.Fatalf("extraSkillDirs = %q, want %q", settings.extraSkillDirs, tc.wantDirs)
+			}
+			for i, want := range tc.wantDirs {
+				if settings.extraSkillDirs[i] != want {
+					t.Errorf("extraSkillDirs[%d] = %q, want %q", i, settings.extraSkillDirs[i], want)
+				}
+			}
+		})
+	}
+}
+
+// kimiFixture builds an isolated home + repo pair for Kimi discovery tests.
+type kimiFixture struct {
+	home string
+	repo string
+}
+
+func newKimiFixture(t *testing.T) kimiFixture {
+	t.Helper()
+	isolateAgentEnv(t)
+	root := t.TempDir()
+	fixture := kimiFixture{
+		home: filepath.Join(root, "home"),
+		repo: filepath.Join(root, "repo"),
+	}
+	mkdirAll(t, fixture.home)
+	mkdirAll(t, fixture.repo)
+	return fixture
+}
+
+func (f kimiFixture) gitRepo(t *testing.T) {
+	t.Helper()
+	mkdirAll(t, filepath.Join(f.repo, ".git"))
+}
+
+func (f kimiFixture) config(t *testing.T, content string) {
+	t.Helper()
+	writeFile(t, filepath.Join(f.home, ".kimi", "config.toml"), content)
+}
+
+func (f kimiFixture) catalog(cwd string) Catalog {
+	return CatalogForProfile("kimi", "kimi", cwd, f.home, nil, "", "0.29.2")
+}
+
+func TestKimiDiscoversProjectKimiSkills(t *testing.T) {
+	f := newKimiFixture(t)
+	f.gitRepo(t)
+	writeSkill(t, filepath.Join(f.repo, ".kimi", "skills"), "deploy", "Ship the service")
+
+	catalog := f.catalog(f.repo)
+	command, ok := commandByName(catalog, "/skill:deploy")
+	if !ok {
+		t.Fatalf("/skill:deploy missing from %d commands", len(catalog.Commands))
+	}
+	if command.Source != "project" {
+		t.Errorf("source = %q, want project", command.Source)
+	}
+	if command.Description != "Ship the service" {
+		t.Errorf("description = %q", command.Description)
+	}
+}
+
+func TestKimiDiscoversProjectSkillsFromSubdirectory(t *testing.T) {
+	f := newKimiFixture(t)
+	f.gitRepo(t)
+	writeSkill(t, filepath.Join(f.repo, ".kimi", "skills"), "deploy", "Ship the service")
+	nested := filepath.Join(f.repo, "services", "api")
+	mkdirAll(t, nested)
+
+	if _, ok := commandByName(f.catalog(nested), "/skill:deploy"); !ok {
+		t.Fatal("walk-up from a subdirectory did not reach the project root's .kimi/skills")
+	}
+}
+
+func TestKimiMergesProjectBrandAndGenericGroups(t *testing.T) {
+	f := newKimiFixture(t)
+	f.gitRepo(t)
+	writeSkill(t, filepath.Join(f.repo, ".claude", "skills"), "review", "Review a diff")
+	writeSkill(t, filepath.Join(f.repo, ".agents", "skills"), "audit", "Audit dependencies")
+
+	catalog := f.catalog(f.repo)
+	for _, name := range []string{"/skill:review", "/skill:audit"} {
+		command, ok := commandByName(catalog, name)
+		if !ok {
+			t.Fatalf("%s missing; merge_all_available_skills defaults to true", name)
+		}
+		if command.Source != "project" {
+			t.Errorf("%s source = %q, want project", name, command.Source)
+		}
+	}
+}
+
+func TestKimiMergesUserBrandDirsByDefault(t *testing.T) {
+	f := newKimiFixture(t)
+	writeSkill(t, filepath.Join(f.home, ".kimi", "skills"), "deploy", "Ship the service")
+	writeSkill(t, filepath.Join(f.home, ".claude", "skills"), "review", "Review a diff")
+
+	catalog := f.catalog(f.repo)
+	for _, name := range []string{"/skill:deploy", "/skill:review"} {
+		command, ok := commandByName(catalog, name)
+		if !ok {
+			t.Fatalf("%s missing; every existing brand directory is merged by default", name)
+		}
+		if command.Source != "personal" {
+			t.Errorf("%s source = %q, want personal", name, command.Source)
+		}
+	}
+}
+
+func TestKimiFirstExistingUserBrandDirWinsWhenMergeDisabled(t *testing.T) {
+	f := newKimiFixture(t)
+	f.config(t, "merge_all_available_skills = false\n")
+	writeSkill(t, filepath.Join(f.home, ".kimi", "skills"), "deploy", "Ship the service")
+	writeSkill(t, filepath.Join(f.home, ".claude", "skills"), "review", "Review a diff")
+
+	catalog := f.catalog(f.repo)
+	command, ok := commandByName(catalog, "/skill:deploy")
+	if !ok {
+		t.Fatal("~/.kimi/skills is the first existing brand directory and must be used")
+	}
+	if command.Source != "personal" {
+		t.Errorf("source = %q, want personal", command.Source)
+	}
+	if _, ok := commandByName(catalog, "/skill:review"); ok {
+		t.Error("merge_all_available_skills = false must use only the first existing brand directory")
+	}
+}
+
+func TestKimiFallsBackToNextUserBrandDirWhenMergeDisabled(t *testing.T) {
+	f := newKimiFixture(t)
+	f.config(t, "merge_all_available_skills = false\n")
+	writeSkill(t, filepath.Join(f.home, ".claude", "skills"), "review", "Review a diff")
+
+	if _, ok := commandByName(f.catalog(f.repo), "/skill:review"); !ok {
+		t.Fatal("~/.claude/skills must be used when ~/.kimi/skills does not exist")
+	}
+}
+
+func TestKimiDiscoversExtraSkillDirs(t *testing.T) {
+	f := newKimiFixture(t)
+	f.config(t, "extra_skill_dirs = [\"~/elsewhere/skills\"]\n")
+	writeSkill(t, filepath.Join(f.home, "elsewhere", "skills"), "brief", "Write a brief")
+
+	command, ok := commandByName(f.catalog(f.repo), "/skill:brief")
+	if !ok {
+		t.Fatal("extra_skill_dirs entry was not scanned")
+	}
+	if command.Source != "personal" {
+		t.Errorf("source = %q, want personal", command.Source)
+	}
+}
+
+func TestKimiProjectSkillBeatsUserSkill(t *testing.T) {
+	f := newKimiFixture(t)
+	f.gitRepo(t)
+	writeSkill(t, filepath.Join(f.home, ".kimi", "skills"), "deploy", "User copy")
+	writeSkill(t, filepath.Join(f.repo, ".kimi", "skills"), "deploy", "Project copy")
+
+	catalog := f.catalog(f.repo)
+	matches := 0
+	for _, command := range catalog.Commands {
+		if command.Command == "/skill:deploy" {
+			matches++
+		}
+	}
+	if matches != 1 {
+		t.Fatalf("/skill:deploy appears %d times, want 1", matches)
+	}
+	command, _ := commandByName(catalog, "/skill:deploy")
+	if command.Description != "Project copy" {
+		t.Errorf("description = %q, want the project copy", command.Description)
+	}
+	if command.Source != "project" {
+		t.Errorf("source = %q, want project", command.Source)
+	}
+}
+
+func TestKimiBrandPriorityWithinOneProjectAncestor(t *testing.T) {
+	f := newKimiFixture(t)
+	f.gitRepo(t)
+	writeSkill(t, filepath.Join(f.repo, ".kimi", "skills"), "deploy", "Kimi copy")
+	writeSkill(t, filepath.Join(f.repo, ".codex", "skills"), "deploy", "Codex copy")
+
+	command, ok := commandByName(f.catalog(f.repo), "/skill:deploy")
+	if !ok {
+		t.Fatal("/skill:deploy missing")
+	}
+	if command.Description != "Kimi copy" {
+		t.Errorf("description = %q, want the .kimi copy: brand priority is kimi > claude > codex",
+			command.Description)
+	}
+}
+
+func TestKimiDropsSkillWithoutDescription(t *testing.T) {
+	f := newKimiFixture(t)
+	f.gitRepo(t)
+	writeSkill(t, filepath.Join(f.repo, ".kimi", "skills"), "deploy", "")
+
+	if _, ok := commandByName(f.catalog(f.repo), "/skill:deploy"); ok {
+		t.Error("a skill without a description must not be listed")
+	}
+}
+
+func TestKimiINIConfiguredFormatSkipsNativeDiscovery(t *testing.T) {
+	f := newKimiFixture(t)
+	f.gitRepo(t)
+	explicit := filepath.Join(f.home, "explicit", "skills")
+	writeSkill(t, explicit, "explicit", "Configured by the relay")
+	writeSkill(t, filepath.Join(f.repo, ".kimi", "skills"), "deploy", "Ship the service")
+
+	catalog := CatalogForProfile("kimi", "kimi", f.repo, f.home,
+		[]string{explicit}, "skill:{name}", "")
+	if _, ok := commandByName(catalog, "/skill:explicit"); !ok {
+		t.Fatal("an INI-configured skill directory must be scanned")
+	}
+	if _, ok := commandByName(catalog, "/skill:deploy"); ok {
+		t.Error("an INI-configured format must skip native discovery")
+	}
+	if countSource(catalog, "project") != 0 {
+		t.Errorf("project sources = %d, want 0", countSource(catalog, "project"))
+	}
+}
+
+func TestKimiGenericGroupIsMutuallyExclusive(t *testing.T) {
+	f := newKimiFixture(t)
+	writeSkill(t, filepath.Join(f.home, ".config", "agents", "skills"), "preferred", "From the recommended dir")
+	writeSkill(t, filepath.Join(f.home, ".agents", "skills"), "secondary", "From the fallback dir")
+
+	catalog := f.catalog(f.repo)
+	if _, ok := commandByName(catalog, "/skill:preferred"); !ok {
+		t.Fatal("~/.config/agents/skills is the first existing generic candidate")
+	}
+	if _, ok := commandByName(catalog, "/skill:secondary"); ok {
+		t.Error("the generic group is mutually exclusive: merge_all_available_skills does not merge it")
+	}
+}
+
+func TestKimiGenericGroupFallsBackToAgentsDir(t *testing.T) {
+	f := newKimiFixture(t)
+	writeSkill(t, filepath.Join(f.home, ".agents", "skills"), "secondary", "From the fallback dir")
+
+	if _, ok := commandByName(f.catalog(f.repo), "/skill:secondary"); !ok {
+		t.Fatal("~/.agents/skills must be used when ~/.config/agents/skills does not exist")
+	}
+}
+
+func TestKimiBrandGroupBeatsGenericGroup(t *testing.T) {
+	f := newKimiFixture(t)
+	f.gitRepo(t)
+	writeSkill(t, filepath.Join(f.home, ".agents", "skills"), "shared", "User generic copy")
+	writeSkill(t, filepath.Join(f.home, ".kimi", "skills"), "shared", "User brand copy")
+	writeSkill(t, filepath.Join(f.repo, ".agents", "skills"), "review", "Project generic copy")
+	writeSkill(t, filepath.Join(f.repo, ".claude", "skills"), "review", "Project brand copy")
+
+	catalog := f.catalog(f.repo)
+	user, ok := commandByName(catalog, "/skill:shared")
+	if !ok {
+		t.Fatal("/skill:shared missing")
+	}
+	if user.Description != "User brand copy" {
+		t.Errorf("user description = %q, want the brand copy", user.Description)
+	}
+	project, ok := commandByName(catalog, "/skill:review")
+	if !ok {
+		t.Fatal("/skill:review missing")
+	}
+	if project.Description != "Project brand copy" {
+		t.Errorf("project description = %q, want the brand copy", project.Description)
+	}
+}
+
+func TestKimiProjectCandidatesResolveAtProjectRootOnly(t *testing.T) {
+	f := newKimiFixture(t)
+	f.gitRepo(t)
+	writeSkill(t, filepath.Join(f.repo, ".kimi", "skills"), "root-skill", "At the project root")
+	nested := filepath.Join(f.repo, "services", "api")
+	writeSkill(t, filepath.Join(nested, ".kimi", "skills"), "nested-skill", "In an intermediate dir")
+
+	catalog := f.catalog(nested)
+	if _, ok := commandByName(catalog, "/skill:root-skill"); !ok {
+		t.Fatal("the project root's .kimi/skills must be scanned from a subdirectory")
+	}
+	if _, ok := commandByName(catalog, "/skill:nested-skill"); ok {
+		t.Error("Kimi resolves project candidates against the project root only, not each ancestor")
+	}
+}
+
+func TestKimiWithoutGitRootUsesWorkDirectory(t *testing.T) {
+	f := newKimiFixture(t)
+	writeSkill(t, filepath.Join(f.repo, ".kimi", "skills"), "deploy", "Ship the service")
+
+	if _, ok := commandByName(f.catalog(f.repo), "/skill:deploy"); !ok {
+		t.Fatal("without a .git marker the work directory is the project root")
+	}
+}
+
+func TestKimiExtraSkillDirsRelativeToProjectRoot(t *testing.T) {
+	f := newKimiFixture(t)
+	f.gitRepo(t)
+	f.config(t, "extra_skill_dirs = [\"vendor/skills\"]\n")
+	writeSkill(t, filepath.Join(f.repo, "vendor", "skills"), "vendored", "From a relative entry")
+	nested := filepath.Join(f.repo, "services", "api")
+	mkdirAll(t, nested)
+
+	command, ok := commandByName(f.catalog(nested), "/skill:vendored")
+	if !ok {
+		t.Fatal("a relative extra_skill_dirs entry resolves against the project root")
+	}
+	if command.Source != "personal" {
+		t.Errorf("source = %q, want personal", command.Source)
+	}
+}
+
+func TestKimiExtraSkillDirsLoseNameCollisions(t *testing.T) {
+	f := newKimiFixture(t)
+	f.config(t, "extra_skill_dirs = [\"~/elsewhere/skills\"]\n")
+	writeSkill(t, filepath.Join(f.home, "elsewhere", "skills"), "deploy", "Extra copy")
+	writeSkill(t, filepath.Join(f.home, ".kimi", "skills"), "deploy", "User copy")
+
+	command, ok := commandByName(f.catalog(f.repo), "/skill:deploy")
+	if !ok {
+		t.Fatal("/skill:deploy missing")
+	}
+	if command.Description != "User copy" {
+		t.Errorf("description = %q, want the user copy: User outranks Extra", command.Description)
+	}
+}
+
+func TestKimiBudgetFavorsHighestPriorityBrandDir(t *testing.T) {
+	f := newKimiFixture(t)
+	writeSkill(t, filepath.Join(f.home, ".kimi", "skills"), "mine", "The kimi skill")
+	bulk := filepath.Join(f.home, ".codex", "skills")
+	for i := range maxCustomFiles {
+		writeSkill(t, bulk, fmt.Sprintf("bulk-%03d", i), "Filler")
+	}
+
+	catalog := f.catalog(f.repo)
+	if !catalog.Truncated {
+		t.Error("exhausting the file budget must mark the catalog truncated")
+	}
+	if _, ok := commandByName(catalog, "/skill:mine"); !ok {
+		t.Fatal("~/.kimi/skills outranks ~/.codex/skills and must be scanned before the budget is spent")
+	}
 }

--- a/internal/slashcmd/kimisettings.go
+++ b/internal/slashcmd/kimisettings.go
@@ -1,0 +1,116 @@
+package slashcmd
+
+import (
+	"regexp"
+	"strings"
+)
+
+// kimiSkillSettings holds the subset of Kimi Code's config.toml that decides
+// which skill directories become /skill:<name> commands. Kimi 0.29.2 documents
+// no per-skill disable and no switch for the skill commands themselves, so
+// there is no ban list here.
+type kimiSkillSettings struct {
+	// mergeAllAvailableSkills selects a candidate group's semantics: true uses
+	// every directory in the group, false only the first that exists.
+	mergeAllAvailableSkills bool
+	extraSkillDirs          []string
+}
+
+// defaultKimiSkillSettings returns Kimi's own defaults: merge everything, no
+// extra directories.
+func defaultKimiSkillSettings() kimiSkillSettings {
+	return kimiSkillSettings{mergeAllAvailableSkills: true}
+}
+
+var kimiTOMLKeyPattern = regexp.MustCompile(`^([A-Za-z0-9_.-]+)[ \t]*=[ \t]*(.*)$`)
+
+// parseKimiSkillSettings applies one config.toml's keys onto s. It understands
+// the constrained TOML subset Kimi's skill settings actually use: flat
+// "key = value" and single-line "key = [a, b]" in the root table, plus the
+// "[table]" headers that end it. Anything it does not understand leaves the
+// affected key at its current value, so a parse gap can only show a command the
+// user could have run, never hide one.
+func parseKimiSkillSettings(data []byte, s *kimiSkillSettings) {
+	root := true
+
+	for _, raw := range strings.Split(strings.ReplaceAll(string(data), "\r\n", "\n"), "\n") {
+		trimmed := strings.TrimSpace(raw)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		if strings.HasPrefix(trimmed, "[") {
+			// A [table] or [[array of tables]] header. Only root-table keys are
+			// consumed, so a same-named key under another table is ignored.
+			root = false
+			continue
+		}
+		if !root {
+			continue
+		}
+		matches := kimiTOMLKeyPattern.FindStringSubmatch(trimmed)
+		if matches == nil {
+			continue
+		}
+		value := strings.TrimSpace(matches[2])
+		switch matches[1] {
+		case "merge_all_available_skills":
+			setScalarBool(&s.mergeAllAvailableSkills, value)
+		case "extra_skill_dirs":
+			setKimiList(&s.extraSkillDirs, value)
+		}
+	}
+}
+
+// setKimiList assigns a list-valued key from a single-line TOML array. List
+// keys replace rather than append across config files. A multi-line array, or
+// any other value, leaves the key untouched: half-parsing a construct this
+// parser does not understand could hide a command.
+func setKimiList(target *[]string, value string) {
+	if items, ok := kimiArrayValue(value); ok {
+		*target = items
+	}
+}
+
+// kimiArrayValue unquotes and trims the items of a single-line TOML array,
+// dropping empty ones. An array that does not close on this line is not
+// understood; an array that closes with nothing in it clears the key.
+func kimiArrayValue(value string) ([]string, bool) {
+	if !strings.HasPrefix(value, "[") {
+		return nil, false
+	}
+	end := kimiArrayEnd(value)
+	if end < 0 {
+		return nil, false
+	}
+	inner := strings.TrimSpace(value[1:end])
+	if inner == "" {
+		return []string{}, true
+	}
+	items := make([]string, 0, strings.Count(inner, ",")+1)
+	for _, field := range strings.Split(inner, ",") {
+		if item := unquoteScalar(field); item != "" {
+			items = append(items, item)
+		}
+	}
+	return items, true
+}
+
+// kimiArrayEnd returns the index of the array's closing bracket, ignoring
+// brackets inside quoted items and any trailing comment, or -1 when the array
+// does not close on this line.
+func kimiArrayEnd(value string) int {
+	quote := byte(0)
+	for i := 1; i < len(value); i++ {
+		switch c := value[i]; {
+		case quote != 0:
+			if c == quote {
+				quote = 0
+			}
+		case c == '\'' || c == '"':
+			quote = c
+		case c == ']':
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/slashcmd/omp.go
+++ b/internal/slashcmd/omp.go
@@ -1,5 +1,22 @@
 package slashcmd
 
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/0cv/herdr-mobile-relay/internal/agentroots"
+)
+
+// ompCommandFormat is the form Oh My Pi registers skills under. Verified against
+// the omp 18.0.3 bundle, which builds `skill:${e.name}` and parses input with
+// `t.startsWith("/skill:")`.
+const ompCommandFormat = "skill:{name}"
+
+// maxSettingsSize caps an agent settings file the relay parses. Generous enough
+// that a real config.yml is never skipped, bounded so a runaway file is.
+const maxSettingsSize = 256 * 1024
+
 type ompProvider struct{}
 
 func (p *ompProvider) ID() string { return "omp" }
@@ -77,8 +94,228 @@ var ompBuiltins = []Command{
 	{"/quit", "Quit OMP", "builtin", ""},
 }
 
+// Discover reproduces Oh My Pi's own skill resolution: every provider omp
+// registers against the skills capability, gated by the toggles in omp's own
+// config.yml, rendered as the /skill:<name> commands omp registers.
+//
+// Sources are scanned in descending omp priority - project scope before user
+// scope within one source, and the innermost ancestor first - with first-wins
+// dedupe, matching omp's own resolution directly. Scanning the winners first
+// also spends the shared file budget on them, so exhaustion truncates the least
+// important skills, never the highest-priority ones.
 func (p *ompProvider) Discover(ctx DiscoverContext) ([]Command, bool) {
-	return builtinsWithGenericSkills(ompBuiltins, ctx)
+	if ctx.CommandFormat != "" {
+		// The relay's INI configured this profile explicitly, which outranks
+		// discovery.
+		custom, truncated := discoverGenericSkills(ctx.SkillDirs, ctx.CommandFormat)
+		return builtinsWithCustom(ompBuiltins, custom), truncated
+	}
+
+	settings := loadOMPSkillSettings(ctx)
+	if !settings.enabled || !settings.enableSkillCommands {
+		builtins := make([]Command, len(ompBuiltins))
+		copy(builtins, ompBuiltins)
+		return builtins, false
+	}
+
+	truncated := false
+	budget := maxCustomFiles
+	active := make(map[string]Command, len(ompBuiltins))
+	order := make([]string, 0, len(ompBuiltins))
+	apply := func(commands []Command) {
+		for _, command := range commands {
+			if _, exists := active[command.Command]; exists {
+				continue
+			}
+			order = append(order, command.Command)
+			active[command.Command] = command
+		}
+	}
+	apply(ompBuiltins)
+
+	// The ban lists apply to skills only; omp's filters run over discovered
+	// skills, never over its own builtin commands.
+	scan := func(scope string, dirs ...string) {
+		for _, dir := range dirs {
+			if dir == "" {
+				continue
+			}
+			cmds, trunc := scanSkillDirFormat(dir, scope, ompCommandFormat, &budget)
+			allowed := cmds[:0]
+			for _, command := range cmds {
+				if settings.allows(ompSkillName(command.Command)) {
+					allowed = append(allowed, command)
+				}
+			}
+			apply(allowed)
+			truncated = truncated || trunc
+		}
+	}
+	// scanProject scans <ancestor>/<stem>/skills in descending precedence:
+	// innermost ancestor first and, within one ancestor, stems in the order omp
+	// lists them. findProjectDirs returns ancestors outermost first with stems
+	// in argument order, so the stems are passed reversed and the flat list is
+	// walked backwards.
+	scanProject := func(stems ...string) {
+		reversed := make([]string, len(stems))
+		for i, stem := range stems {
+			reversed[len(stems)-1-i] = stem
+		}
+		dirs := findProjectDirs(ctx.Cwd, reversed)
+		for i := len(dirs) - 1; i >= 0; i-- {
+			scan("project", filepath.Join(dirs[i], "skills"))
+		}
+	}
+
+	fallback := settings.sourceFallbackEnabled()
+
+	// 1. native (100)
+	if settings.enablePiProject {
+		scanProject(".omp")
+	}
+	if settings.enablePiUser {
+		scan("personal", agentroots.OMPSkillDirs(ctx.Home)...)
+	}
+
+	// 2. claude (80)
+	if settings.enableClaudeProject {
+		scanProject(".claude")
+	}
+	if settings.enableClaudeUser {
+		scan("personal", filepath.Join(ctx.Home, ".claude", "skills"))
+	}
+
+	// 3. codex (70). omp scans a project .codex/skills even though codex
+	// itself has no such directory, and that project level has no toggle of
+	// its own.
+	if fallback {
+		scanProject(".codex")
+	}
+	if settings.enableCodexUser {
+		scan("personal", filepath.Join(ctx.Home, ".codex", "skills"))
+	}
+
+	// 4. agents (70)
+	if settings.enableAgentsProject {
+		scanProject(".agent", ".agents")
+	}
+	if settings.enableAgentsUser {
+		scan("personal",
+			filepath.Join(ctx.Home, ".agent", "skills"),
+			filepath.Join(ctx.Home, ".agents", "skills"))
+	}
+
+	// 5. opencode (55)
+	if fallback {
+		scanProject(".opencode")
+		scan("personal", filepath.Join(ctx.Home, ".config", "opencode", "skills"))
+	}
+
+	// 6. github (30)
+	if fallback {
+		scanProject(".github")
+	}
+
+	// 7. customDirectories - subject to the ban lists but not to source
+	// toggles. Scanned after every toggled source, so an authored skill of the
+	// same name wins the collision.
+	for _, dir := range settings.customDirectories {
+		scan("personal", expandTilde(dir, ctx.Home))
+	}
+
+	// 8. managed (priority 5) - always enabled, scanned last so it loses every
+	// collision.
+	scan("personal", agentroots.OMPManagedSkillDirs(ctx.Home)...)
+
+	commands := make([]Command, 0, len(order))
+	for _, name := range order {
+		if command, exists := active[name]; exists {
+			commands = append(commands, command)
+		}
+	}
+	if budget <= 0 {
+		truncated = true
+	}
+	return commands, truncated
+}
+
+// ompSkillName recovers the skill name from a rendered /skill:<name> command.
+// A builtin has no such prefix and is returned unchanged, which the ban lists
+// never match because omp bans skills, not builtins.
+func ompSkillName(command string) string {
+	return strings.TrimPrefix(command, "/skill:")
+}
+
+// loadOMPSkillSettings reads the first config.yml (or config.yaml) found across
+// omp's agent directories, then overlays every project-level .omp config from
+// the git root down to the cwd. Where several profiles exist the relay cannot
+// know which one the pane runs, so first-found wins for the user level: the
+// search stops at the first directory containing a config file even when that
+// file cannot be read, because falling through would apply an unrelated
+// profile's settings. The innermost repo scope is applied last, matching omp's
+// precedence, and list-valued keys replace rather than append.
+func loadOMPSkillSettings(ctx DiscoverContext) ompSkillSettings {
+	settings := defaultOMPSkillSettings()
+	for _, dir := range agentroots.OMPConfigDirs(ctx.Home) {
+		data, found, ok := settingsFileIn(dir, "config.yml", "config.yaml")
+		if !found {
+			continue
+		}
+		if ok {
+			parseOMPSkillSettings(data, &settings)
+		}
+		break
+	}
+	for _, dir := range findProjectDirs(ctx.Cwd, []string{".omp"}) {
+		if data, ok := readSettingsFile(dir, "config.yml", "config.yaml"); ok {
+			parseOMPSkillSettings(data, &settings)
+		}
+	}
+	return settings
+}
+
+// readSettingsFile returns the contents of the first readable name in dir.
+func readSettingsFile(dir string, names ...string) ([]byte, bool) {
+	data, _, ok := settingsFileIn(dir, names...)
+	return data, ok
+}
+
+// settingsFileIn reads the first usable candidate name in dir. found reports
+// that dir contains any candidate at all, readable or not, which is what a
+// first-found-wins search over agent directories must stop on; ok reports that
+// data was actually read. A candidate is unusable when it is not a regular
+// file, exceeds maxSettingsSize, or cannot be read.
+func settingsFileIn(dir string, names ...string) ([]byte, bool, bool) {
+	found := false
+	for _, name := range names {
+		path := filepath.Join(dir, name)
+		info, err := os.Stat(path)
+		if err != nil {
+			continue
+		}
+		found = true
+		if !info.Mode().IsRegular() || info.Size() > maxSettingsSize {
+			continue
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		return data, true, true
+	}
+	return nil, found, false
+}
+
+// expandTilde resolves a leading "~" against home, matching how omp expands
+// customDirectories.
+func expandTilde(path, home string) string {
+	if path == "~" {
+		return home
+	}
+	if rest, ok := strings.CutPrefix(path, "~/"); ok {
+		return filepath.Join(home, rest)
+	}
+	return path
 }
 
 func init() {

--- a/internal/slashcmd/omp_discovery_test.go
+++ b/internal/slashcmd/omp_discovery_test.go
@@ -1,0 +1,469 @@
+package slashcmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// ompFixture builds an isolated home + repo pair for omp discovery tests.
+type ompFixture struct {
+	home string
+	repo string
+}
+
+func newOMPFixture(t *testing.T) ompFixture {
+	t.Helper()
+	isolateAgentEnv(t)
+	root := t.TempDir()
+	fixture := ompFixture{
+		home: filepath.Join(root, "home"),
+		repo: filepath.Join(root, "repo"),
+	}
+	mkdirAll(t, filepath.Join(fixture.home, ".omp", "agent"))
+	mkdirAll(t, fixture.repo)
+	return fixture
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	mkdirAll(t, filepath.Dir(path))
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+// writeSkill creates <dir>/<name>/SKILL.md with frontmatter.
+func writeSkill(t *testing.T, dir, name, description string) {
+	t.Helper()
+	body := "---\nname: " + name + "\n"
+	if description != "" {
+		body += "description: " + description + "\n"
+	}
+	body += "---\n\nbody\n"
+	writeFile(t, filepath.Join(dir, name, "SKILL.md"), body)
+}
+
+func (f ompFixture) gitRepo(t *testing.T) {
+	t.Helper()
+	mkdirAll(t, filepath.Join(f.repo, ".git"))
+}
+
+func (f ompFixture) catalog(cwd string) Catalog {
+	return CatalogForProfile("omp", "omp", cwd, f.home, nil, "", "18.0.3")
+}
+
+func commandByName(catalog Catalog, name string) (Command, bool) {
+	for _, command := range catalog.Commands {
+		if command.Command == name {
+			return command, true
+		}
+	}
+	return Command{}, false
+}
+
+func countSource(catalog Catalog, source string) int {
+	total := 0
+	for _, command := range catalog.Commands {
+		if command.Source == source {
+			total++
+		}
+	}
+	return total
+}
+
+func TestOMPDiscoversProjectOMPSkills(t *testing.T) {
+	f := newOMPFixture(t)
+	f.gitRepo(t)
+	writeSkill(t, filepath.Join(f.repo, ".omp", "skills"), "deploy", "Ship the service")
+
+	catalog := f.catalog(f.repo)
+	command, ok := commandByName(catalog, "/skill:deploy")
+	if !ok {
+		t.Fatalf("/skill:deploy missing from %d commands", len(catalog.Commands))
+	}
+	if command.Source != "project" {
+		t.Errorf("source = %q, want project", command.Source)
+	}
+	if command.Description != "Ship the service" {
+		t.Errorf("description = %q", command.Description)
+	}
+}
+
+func TestOMPDiscoversProjectSkillsFromSubdirectory(t *testing.T) {
+	f := newOMPFixture(t)
+	f.gitRepo(t)
+	writeSkill(t, filepath.Join(f.repo, ".omp", "skills"), "deploy", "Ship the service")
+	nested := filepath.Join(f.repo, "services", "api")
+	mkdirAll(t, nested)
+
+	if _, ok := commandByName(f.catalog(nested), "/skill:deploy"); !ok {
+		t.Fatal("walk-up from a subdirectory did not reach the git root's .omp/skills")
+	}
+}
+
+func TestOMPDiscoversClaudeProjectSkills(t *testing.T) {
+	f := newOMPFixture(t)
+	f.gitRepo(t)
+	writeSkill(t, filepath.Join(f.repo, ".claude", "skills"), "review", "Review a diff")
+
+	command, ok := commandByName(f.catalog(f.repo), "/skill:review")
+	if !ok {
+		t.Fatal("omp must discover .claude/skills")
+	}
+	if command.Source != "project" {
+		t.Errorf("source = %q, want project", command.Source)
+	}
+}
+
+func TestOMPHonoursEnableClaudeProjectFalse(t *testing.T) {
+	f := newOMPFixture(t)
+	f.gitRepo(t)
+	writeSkill(t, filepath.Join(f.repo, ".omp", "skills"), "deploy", "Ship the service")
+	writeSkill(t, filepath.Join(f.repo, ".claude", "skills"), "review", "Review a diff")
+	writeFile(t, filepath.Join(f.home, ".omp", "agent", "config.yml"),
+		"skills:\n  enableClaudeProject: false\n")
+
+	catalog := f.catalog(f.repo)
+	if _, ok := commandByName(catalog, "/skill:review"); ok {
+		t.Error("enableClaudeProject: false must hide .claude/skills")
+	}
+	if _, ok := commandByName(catalog, "/skill:deploy"); !ok {
+		t.Error(".omp/skills must remain visible")
+	}
+}
+
+func TestOMPHonoursDisabledExtensions(t *testing.T) {
+	f := newOMPFixture(t)
+	f.gitRepo(t)
+	writeSkill(t, filepath.Join(f.repo, ".omp", "skills"), "deploy", "Ship the service")
+	writeSkill(t, filepath.Join(f.repo, ".omp", "skills"), "audit", "Audit the tree")
+	writeFile(t, filepath.Join(f.home, ".omp", "agent", "config.yml"),
+		"disabledExtensions:\n  - skill:deploy\n  - plugin:foo\n")
+
+	catalog := f.catalog(f.repo)
+	if _, ok := commandByName(catalog, "/skill:deploy"); ok {
+		t.Error("skill:deploy must be banned")
+	}
+	if _, ok := commandByName(catalog, "/skill:audit"); !ok {
+		t.Error("plugin:foo must not affect skills")
+	}
+}
+
+func TestOMPSkillCommandsDisabledYieldsBuiltinsOnly(t *testing.T) {
+	f := newOMPFixture(t)
+	f.gitRepo(t)
+	writeSkill(t, filepath.Join(f.repo, ".omp", "skills"), "deploy", "Ship the service")
+	writeFile(t, filepath.Join(f.home, ".omp", "agent", "config.yml"),
+		"skills:\n  enableSkillCommands: false\n")
+
+	catalog := f.catalog(f.repo)
+	if len(catalog.Commands) != len(ompBuiltins) {
+		t.Fatalf("commands = %d, want %d builtins", len(catalog.Commands), len(ompBuiltins))
+	}
+	if countSource(catalog, "builtin") != len(ompBuiltins) {
+		t.Error("every command should be a builtin")
+	}
+}
+
+func TestOMPSkillsDisabledYieldsBuiltinsOnly(t *testing.T) {
+	f := newOMPFixture(t)
+	f.gitRepo(t)
+	writeSkill(t, filepath.Join(f.repo, ".omp", "skills"), "deploy", "Ship the service")
+	writeFile(t, filepath.Join(f.home, ".omp", "agent", "config.yml"),
+		"skills:\n  enabled: false\n")
+
+	if len(f.catalog(f.repo).Commands) != len(ompBuiltins) {
+		t.Fatal("skills.enabled: false must yield builtins only")
+	}
+}
+
+func TestOMPDropsSkillWithoutDescription(t *testing.T) {
+	f := newOMPFixture(t)
+	f.gitRepo(t)
+	writeSkill(t, filepath.Join(f.repo, ".omp", "skills"), "nodesc", "")
+
+	if _, ok := commandByName(f.catalog(f.repo), "/skill:nodesc"); ok {
+		t.Fatal("a skill without a description must not be listed")
+	}
+}
+
+func TestOMPNativeBeatsClaudeOnNameCollision(t *testing.T) {
+	f := newOMPFixture(t)
+	f.gitRepo(t)
+	writeSkill(t, filepath.Join(f.repo, ".omp", "skills"), "deploy", "native description")
+	writeSkill(t, filepath.Join(f.repo, ".claude", "skills"), "deploy", "claude description")
+
+	catalog := f.catalog(f.repo)
+	seen := 0
+	for _, command := range catalog.Commands {
+		if command.Command == "/skill:deploy" {
+			seen++
+		}
+	}
+	if seen != 1 {
+		t.Fatalf("/skill:deploy appears %d times, want 1", seen)
+	}
+	command, _ := commandByName(catalog, "/skill:deploy")
+	if command.Description != "native description" {
+		t.Fatalf("description = %q, want the .omp one", command.Description)
+	}
+}
+
+func TestOMPProjectSkillBeatsUserSkill(t *testing.T) {
+	f := newOMPFixture(t)
+	f.gitRepo(t)
+	writeSkill(t, filepath.Join(f.home, ".omp", "agent", "skills"), "deploy", "user description")
+	writeSkill(t, filepath.Join(f.repo, ".omp", "skills"), "deploy", "project description")
+
+	command, ok := commandByName(f.catalog(f.repo), "/skill:deploy")
+	if !ok {
+		t.Fatal("/skill:deploy missing")
+	}
+	if command.Description != "project description" || command.Source != "project" {
+		t.Fatalf("project scope should win, got %+v", command)
+	}
+}
+
+func TestOMPDiscoversUserSkillsFromProfileAgentDir(t *testing.T) {
+	f := newOMPFixture(t)
+	writeSkill(t, filepath.Join(f.home, ".omp", "profiles", "personal", "agent", "skills"),
+		"profile-skill", "From a named profile")
+
+	command, ok := commandByName(f.catalog(f.repo), "/skill:profile-skill")
+	if !ok {
+		t.Fatal("a named profile's skills must be discovered")
+	}
+	if command.Source != "personal" {
+		t.Errorf("source = %q, want personal", command.Source)
+	}
+}
+
+func TestOMPDiscoversCustomDirectories(t *testing.T) {
+	f := newOMPFixture(t)
+	custom := filepath.Join(f.home, "elsewhere", "skills")
+	writeSkill(t, custom, "custom-one", "From a custom directory")
+	writeFile(t, filepath.Join(f.home, ".omp", "agent", "config.yml"),
+		"skills:\n  enablePiUser: false\n  customDirectories:\n    - ~/elsewhere/skills\n")
+
+	command, ok := commandByName(f.catalog(f.repo), "/skill:custom-one")
+	if !ok {
+		t.Fatal("customDirectories must be scanned even with source toggles off")
+	}
+	if command.Source != "personal" {
+		t.Errorf("source = %q, want personal", command.Source)
+	}
+}
+
+func TestOMPHonoursProjectConfigOverlay(t *testing.T) {
+	f := newOMPFixture(t)
+	f.gitRepo(t)
+	writeSkill(t, filepath.Join(f.repo, ".omp", "skills"), "deploy", "Ship the service")
+	writeSkill(t, filepath.Join(f.repo, ".claude", "skills"), "review", "Review a diff")
+	writeFile(t, filepath.Join(f.repo, ".omp", "config.yml"),
+		"skills:\n  enableClaudeProject: false\n")
+
+	catalog := f.catalog(f.repo)
+	if _, ok := commandByName(catalog, "/skill:review"); ok {
+		t.Error("a repo's own .omp/config.yml must be able to hide .claude/skills")
+	}
+	if _, ok := commandByName(catalog, "/skill:deploy"); !ok {
+		t.Error(".omp/skills must remain visible")
+	}
+}
+
+func TestOMPProjectConfigOverridesUserConfig(t *testing.T) {
+	f := newOMPFixture(t)
+	f.gitRepo(t)
+	writeSkill(t, filepath.Join(f.repo, ".claude", "skills"), "review", "Review a diff")
+	writeFile(t, filepath.Join(f.home, ".omp", "agent", "config.yml"),
+		"skills:\n  enableClaudeProject: false\n")
+	writeFile(t, filepath.Join(f.repo, ".omp", "config.yml"),
+		"skills:\n  enableClaudeProject: true\n")
+
+	if _, ok := commandByName(f.catalog(f.repo), "/skill:review"); !ok {
+		t.Fatal("the repo config is applied last and must win")
+	}
+}
+
+func TestOMPUserSkillsIgnoredWhenPiUserDisabled(t *testing.T) {
+	f := newOMPFixture(t)
+	writeSkill(t, filepath.Join(f.home, ".omp", "agent", "skills"), "user-skill", "A user skill")
+	writeFile(t, filepath.Join(f.home, ".omp", "agent", "config.yml"),
+		"skills:\n  enablePiUser: false\n")
+
+	if _, ok := commandByName(f.catalog(f.repo), "/skill:user-skill"); ok {
+		t.Fatal("enablePiUser: false must hide the native user skills")
+	}
+}
+
+func TestOMPManagedSkillsAlwaysScanned(t *testing.T) {
+	f := newOMPFixture(t)
+	writeSkill(t, filepath.Join(f.home, ".omp", "agent", "managed-skills"), "managed-one", "A managed skill")
+	writeFile(t, filepath.Join(f.home, ".omp", "agent", "config.yml"),
+		"skills:\n  enablePiUser: false\n  enableClaudeUser: false\n  enableClaudeProject: false\n  enableCodexUser: false\n  enablePiProject: false\n")
+
+	if _, ok := commandByName(f.catalog(f.repo), "/skill:managed-one"); !ok {
+		t.Fatal("managed skills are always enabled")
+	}
+}
+
+func TestOMPFallThroughGateClosesGitHubSource(t *testing.T) {
+	f := newOMPFixture(t)
+	f.gitRepo(t)
+	writeSkill(t, filepath.Join(f.repo, ".github", "skills"), "gh-one", "A GitHub skill")
+
+	if _, ok := commandByName(f.catalog(f.repo), "/skill:gh-one"); !ok {
+		t.Fatal("the default fall-through gate is open, .github/skills should be listed")
+	}
+
+	writeFile(t, filepath.Join(f.home, ".omp", "agent", "config.yml"),
+		"skills:\n  enableCodexUser: false\n  enableClaudeUser: false\n  enableClaudeProject: false\n  enablePiUser: false\n  enablePiProject: false\n")
+	if _, ok := commandByName(f.catalog(f.repo), "/skill:gh-one"); ok {
+		t.Fatal("all five toggles off must close the fall-through gate")
+	}
+}
+
+func TestOMPIgnoredSkillsGlob(t *testing.T) {
+	f := newOMPFixture(t)
+	f.gitRepo(t)
+	writeSkill(t, filepath.Join(f.repo, ".omp", "skills"), "noisy-one", "Noisy")
+	writeSkill(t, filepath.Join(f.repo, ".omp", "skills"), "quiet", "Quiet")
+	writeFile(t, filepath.Join(f.home, ".omp", "agent", "config.yml"),
+		"skills:\n  ignoredSkills:\n    - noisy-*\n")
+
+	catalog := f.catalog(f.repo)
+	if _, ok := commandByName(catalog, "/skill:noisy-one"); ok {
+		t.Error("ignoredSkills glob must ban noisy-one")
+	}
+	if _, ok := commandByName(catalog, "/skill:quiet"); !ok {
+		t.Error("quiet must survive")
+	}
+}
+
+func TestOMPIncludeSkillsActsAsAllowList(t *testing.T) {
+	f := newOMPFixture(t)
+	f.gitRepo(t)
+	writeSkill(t, filepath.Join(f.repo, ".omp", "skills"), "wanted", "Wanted")
+	writeSkill(t, filepath.Join(f.repo, ".omp", "skills"), "other", "Other")
+	writeFile(t, filepath.Join(f.home, ".omp", "agent", "config.yml"),
+		"skills:\n  includeSkills: [wanted]\n")
+
+	catalog := f.catalog(f.repo)
+	if _, ok := commandByName(catalog, "/skill:other"); ok {
+		t.Error("includeSkills must exclude unlisted skills")
+	}
+	if _, ok := commandByName(catalog, "/skill:wanted"); !ok {
+		t.Error("wanted must be listed")
+	}
+	if len(catalog.Commands) != len(ompBuiltins)+1 {
+		t.Errorf("commands = %d, want %d", len(catalog.Commands), len(ompBuiltins)+1)
+	}
+}
+
+func TestOMPFollowsSymlinkedSkillDirectory(t *testing.T) {
+	f := newOMPFixture(t)
+	f.gitRepo(t)
+	real := filepath.Join(f.home, "dotfiles", "deploy")
+	writeFile(t, filepath.Join(real, "SKILL.md"), "---\nname: deploy\ndescription: Ship it\n---\n")
+	skillsDir := filepath.Join(f.repo, ".omp", "skills")
+	mkdirAll(t, skillsDir)
+	if err := os.Symlink(real, filepath.Join(skillsDir, "deploy")); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	if _, ok := commandByName(f.catalog(f.repo), "/skill:deploy"); !ok {
+		t.Fatal("a symlinked skill directory must be followed")
+	}
+}
+
+func TestOMPINIConfiguredFormatSkipsNativeDiscovery(t *testing.T) {
+	f := newOMPFixture(t)
+	f.gitRepo(t)
+	writeSkill(t, filepath.Join(f.repo, ".omp", "skills"), "deploy", "Ship the service")
+	explicit := filepath.Join(f.home, "explicit", "skills")
+	writeSkill(t, explicit, "explicit-one", "Explicitly configured")
+
+	catalog := CatalogForProfile("omp", "omp", f.repo, f.home,
+		[]string{explicit}, "skill:{name}", "18.0.3")
+	if _, ok := commandByName(catalog, "/skill:explicit-one"); !ok {
+		t.Error("the INI-configured directory must be scanned")
+	}
+	if _, ok := commandByName(catalog, "/skill:deploy"); ok {
+		t.Error("explicit configuration outranks discovery, so native discovery is skipped")
+	}
+}
+
+func TestOMPUnusableConfigStopsAtFirstConfigDir(t *testing.T) {
+	f := newOMPFixture(t)
+	f.gitRepo(t)
+	writeSkill(t, filepath.Join(f.repo, ".omp", "skills"), "deploy", "Ship the service")
+	writeFile(t, filepath.Join(f.home, ".omp", "profiles", "personal", "agent", "config.yml"),
+		strings.Repeat(" ", maxSettingsSize+1))
+	writeFile(t, filepath.Join(f.home, ".omp", "agent", "config.yml"),
+		"disabledExtensions:\n  - skill:deploy\n")
+
+	if _, ok := commandByName(f.catalog(f.repo), "/skill:deploy"); !ok {
+		t.Fatal("first-found wins: an unusable config.yml in the first agent directory must stop the search and fail open, not fall through to another profile's bans")
+	}
+}
+
+func TestOMPProfileConfigGovernsDiscovery(t *testing.T) {
+	f := newOMPFixture(t)
+	f.gitRepo(t)
+	writeSkill(t, filepath.Join(f.repo, ".omp", "skills"), "deploy", "Ship the service")
+	writeSkill(t, filepath.Join(f.repo, ".omp", "skills"), "audit", "Audit the tree")
+	writeFile(t, filepath.Join(f.home, ".omp", "profiles", "personal", "agent", "config.yml"),
+		"disabledExtensions:\n  - skill:deploy\n")
+
+	catalog := f.catalog(f.repo)
+	if _, ok := commandByName(catalog, "/skill:deploy"); ok {
+		t.Error("a named profile's config.yml must be found and its bans applied")
+	}
+	if _, ok := commandByName(catalog, "/skill:audit"); !ok {
+		t.Error("discovery must stay on for skills the profile does not ban")
+	}
+}
+
+func TestOMPBudgetFavorsHighestPrioritySource(t *testing.T) {
+	f := newOMPFixture(t)
+	f.gitRepo(t)
+	writeSkill(t, filepath.Join(f.repo, ".omp", "skills"), "mine", "The native skill")
+	bulk := filepath.Join(f.repo, ".github", "skills")
+	for i := range maxCustomFiles {
+		writeSkill(t, bulk, fmt.Sprintf("bulk-%03d", i), "Filler")
+	}
+
+	catalog := f.catalog(f.repo)
+	if !catalog.Truncated {
+		t.Error("exhausting the file budget must mark the catalog truncated")
+	}
+	if _, ok := commandByName(catalog, "/skill:mine"); !ok {
+		t.Fatal("the highest-priority source must be scanned before the budget is spent on low-priority ones")
+	}
+}
+
+func TestFindProjectDirsWalksIntermediateAncestors(t *testing.T) {
+	root := t.TempDir()
+	mkdirAll(t, filepath.Join(root, ".git"))
+	cwd := filepath.Join(root, "services", "api")
+	outer := filepath.Join(root, ".omp")
+	middle := filepath.Join(root, "services", ".omp")
+	inner := filepath.Join(cwd, ".omp")
+	for _, dir := range []string{outer, middle, inner} {
+		mkdirAll(t, dir)
+	}
+
+	dirs := findProjectDirs(cwd, []string{".omp"})
+	want := []string{outer, middle, inner}
+	if len(dirs) != len(want) {
+		t.Fatalf("dirs = %v, want %v", dirs, want)
+	}
+	for i := range want {
+		if dirs[i] != want[i] {
+			t.Fatalf("dirs = %v, want %v (outermost first, intermediate ancestors included)", dirs, want)
+		}
+	}
+}

--- a/internal/slashcmd/omp_test.go
+++ b/internal/slashcmd/omp_test.go
@@ -3,7 +3,8 @@ package slashcmd
 import "testing"
 
 func TestOMPBuiltinCatalog(t *testing.T) {
-	catalog := CatalogForProfile("omp", "omp", "/tmp", "/nonexistent", nil, "", "17.1.7")
+	isolateAgentEnv(t)
+	catalog := CatalogForProfile("omp", "omp", t.TempDir(), "/nonexistent", nil, "", "17.1.7")
 	if catalog.Truncated {
 		t.Fatal("builtins-only catalog is truncated")
 	}

--- a/internal/slashcmd/ompsettings.go
+++ b/internal/slashcmd/ompsettings.go
@@ -1,0 +1,292 @@
+package slashcmd
+
+import (
+	"path"
+	"regexp"
+	"strings"
+)
+
+// ompSkillSettings holds the subset of Oh My Pi's settings that decides which
+// skills become /skill:<name> commands. Every boolean defaults to true, so an
+// unreadable or unparsable config file yields the agent's own defaults.
+type ompSkillSettings struct {
+	enabled             bool
+	enableSkillCommands bool
+	enableCodexUser     bool
+	enableClaudeUser    bool
+	enableClaudeProject bool
+	enablePiUser        bool
+	enablePiProject     bool
+	enableAgentsUser    bool
+	enableAgentsProject bool
+	customDirectories   []string
+	ignoredSkills       []string
+	includeSkills       []string
+	// disabledSkills holds names from the top-level disabledExtensions list that
+	// carried the "skill:" prefix.
+	disabledSkills map[string]bool
+}
+
+// defaultOMPSkillSettings returns the all-enabled, no-bans default.
+func defaultOMPSkillSettings() ompSkillSettings {
+	return ompSkillSettings{
+		enabled:             true,
+		enableSkillCommands: true,
+		enableCodexUser:     true,
+		enableClaudeUser:    true,
+		enableClaudeProject: true,
+		enablePiUser:        true,
+		enablePiProject:     true,
+		enableAgentsUser:    true,
+		enableAgentsProject: true,
+		disabledSkills:      map[string]bool{},
+	}
+}
+
+// sourceFallbackEnabled reports the gate omp applies to providers with no
+// toggle of their own (github, opencode, plugins, and project-level codex).
+func (s *ompSkillSettings) sourceFallbackEnabled() bool {
+	return s.enableCodexUser || s.enableClaudeUser || s.enableClaudeProject ||
+		s.enablePiUser || s.enablePiProject
+}
+
+// allows reports whether a skill name survives omp's ban filters, applied in
+// omp's own order: disabledExtensions, then ignoredSkills, then includeSkills.
+func (s *ompSkillSettings) allows(name string) bool {
+	if s.disabledSkills[name] {
+		return false
+	}
+	for _, pattern := range s.ignoredSkills {
+		if matched, err := path.Match(pattern, name); err == nil && matched {
+			return false
+		}
+	}
+	if len(s.includeSkills) == 0 {
+		return true
+	}
+	for _, pattern := range s.includeSkills {
+		if matched, err := path.Match(pattern, name); err == nil && matched {
+			return true
+		}
+	}
+	return false
+}
+
+var ompYAMLKeyPattern = regexp.MustCompile(`^([A-Za-z0-9_.-]+):(?:[ \t]+(.*))?$`)
+
+// parseOMPSkillSettings applies one config file's keys onto s. It understands
+// the constrained YAML subset omp's config actually uses: top-level keys, one
+// level of nesting under "skills", block and flow lists, and boolean scalars.
+// Anything it does not understand leaves the affected key at its current value,
+// so a parse gap can only show a command the user could have run, never hide
+// one.
+func parseOMPSkillSettings(data []byte, s *ompSkillSettings) {
+	const (
+		modeNone = iota
+		modeSkills
+		modeDisabled
+	)
+	mode := modeNone
+	childIndent := -1
+	var listTarget *[]string
+
+	for _, raw := range strings.Split(strings.ReplaceAll(string(data), "\r\n", "\n"), "\n") {
+		line := strings.TrimRight(raw, " \t")
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		leading := line[:len(line)-len(strings.TrimLeft(line, " \t"))]
+		if strings.Contains(leading, "\t") {
+			continue
+		}
+		indent := len(leading)
+
+		if indent == 0 {
+			mode = modeNone
+			childIndent = -1
+			listTarget = nil
+			key, value, ok := splitOMPKey(trimmed)
+			if !ok {
+				continue
+			}
+			switch key {
+			case "skills":
+				if value == "" {
+					mode = modeSkills
+				}
+			case "disabledExtensions":
+				items, listed, block := ompListValue(value)
+				if block {
+					s.disabledSkills = map[string]bool{}
+					mode = modeDisabled
+					continue
+				}
+				if !listed {
+					continue
+				}
+				s.disabledSkills = map[string]bool{}
+				for _, item := range items {
+					addDisabledSkill(s, item)
+				}
+			}
+			continue
+		}
+
+		switch mode {
+		case modeDisabled:
+			if item, ok := ompListItem(trimmed); ok {
+				addDisabledSkill(s, item)
+			}
+		case modeSkills:
+			if item, ok := ompListItem(trimmed); ok {
+				if listTarget != nil && item != "" {
+					*listTarget = append(*listTarget, item)
+				}
+				continue
+			}
+			key, value, ok := splitOMPKey(trimmed)
+			if !ok {
+				continue
+			}
+			if childIndent == -1 {
+				childIndent = indent
+			}
+			if indent > childIndent {
+				// Deeper than a direct child of "skills:" - part of a construct
+				// this parser does not consume.
+				listTarget = nil
+				continue
+			}
+			listTarget = nil
+			switch key {
+			case "enabled":
+				setScalarBool(&s.enabled, value)
+			case "enableSkillCommands":
+				setScalarBool(&s.enableSkillCommands, value)
+			case "enableCodexUser":
+				setScalarBool(&s.enableCodexUser, value)
+			case "enableClaudeUser":
+				setScalarBool(&s.enableClaudeUser, value)
+			case "enableClaudeProject":
+				setScalarBool(&s.enableClaudeProject, value)
+			case "enablePiUser":
+				setScalarBool(&s.enablePiUser, value)
+			case "enablePiProject":
+				setScalarBool(&s.enablePiProject, value)
+			case "enableAgentsUser":
+				setScalarBool(&s.enableAgentsUser, value)
+			case "enableAgentsProject":
+				setScalarBool(&s.enableAgentsProject, value)
+			case "customDirectories":
+				listTarget = setOMPList(&s.customDirectories, value)
+			case "ignoredSkills":
+				listTarget = setOMPList(&s.ignoredSkills, value)
+			case "includeSkills":
+				listTarget = setOMPList(&s.includeSkills, value)
+			}
+		}
+	}
+}
+
+func addDisabledSkill(s *ompSkillSettings, id string) {
+	name, ok := strings.CutPrefix(id, "skill:")
+	if !ok || name == "" {
+		return
+	}
+	if s.disabledSkills == nil {
+		s.disabledSkills = map[string]bool{}
+	}
+	s.disabledSkills[name] = true
+}
+
+// setOMPList assigns a list-valued key. List keys replace rather than append
+// across config levels, matching omp's own merge semantics. A block-form key
+// returns the slice so following "- item" lines extend it; a value the parser
+// does not understand leaves the key untouched.
+func setOMPList(target *[]string, value string) *[]string {
+	items, listed, block := ompListValue(value)
+	if block {
+		*target = nil
+		return target
+	}
+	if !listed {
+		return nil
+	}
+	*target = items
+	return nil
+}
+
+// ompListValue interprets the scalar part of a list-valued key. block reports
+// the "key:" form whose items follow on later lines; listed reports a flow
+// list; neither means the value was not understood.
+func ompListValue(value string) (items []string, listed, block bool) {
+	if value == "" {
+		return nil, false, true
+	}
+	value = stripScalarComment(value)
+	if !strings.HasPrefix(value, "[") || !strings.HasSuffix(value, "]") {
+		return nil, false, false
+	}
+	inner := strings.TrimSpace(value[1 : len(value)-1])
+	if inner == "" {
+		return nil, true, false
+	}
+	for _, field := range strings.Split(inner, ",") {
+		if item := unquoteScalar(field); item != "" {
+			items = append(items, item)
+		}
+	}
+	return items, true, false
+}
+
+func ompListItem(trimmed string) (string, bool) {
+	rest, ok := strings.CutPrefix(trimmed, "-")
+	if !ok {
+		return "", false
+	}
+	if rest != "" && !strings.HasPrefix(rest, " ") && !strings.HasPrefix(rest, "\t") {
+		return "", false
+	}
+	return unquoteScalar(stripScalarComment(strings.TrimSpace(rest))), true
+}
+
+func splitOMPKey(trimmed string) (key, value string, ok bool) {
+	matches := ompYAMLKeyPattern.FindStringSubmatch(trimmed)
+	if matches == nil {
+		return "", "", false
+	}
+	return matches[1], strings.TrimSpace(matches[2]), true
+}
+
+// setScalarBool applies a boolean scalar, accepting true/false case
+// insensitively and optionally quoted. Any other scalar leaves the target
+// alone. Shared by the YAML and TOML settings parsers.
+func setScalarBool(target *bool, value string) {
+	switch strings.ToLower(unquoteScalar(stripScalarComment(value))) {
+	case "true":
+		*target = true
+	case "false":
+		*target = false
+	}
+}
+
+// stripScalarComment removes a trailing comment from an unquoted scalar. Both
+// YAML and TOML start a comment with "#".
+func stripScalarComment(value string) string {
+	if strings.HasPrefix(value, "\"") || strings.HasPrefix(value, "'") {
+		return value
+	}
+	if index := strings.Index(value, " #"); index >= 0 {
+		return strings.TrimSpace(value[:index])
+	}
+	return value
+}
+
+func unquoteScalar(value string) string {
+	value = strings.TrimSpace(value)
+	if len(value) >= 2 && value[0] == value[len(value)-1] && (value[0] == '\'' || value[0] == '"') {
+		value = value[1 : len(value)-1]
+	}
+	return strings.TrimSpace(value)
+}

--- a/internal/slashcmd/ompsettings_test.go
+++ b/internal/slashcmd/ompsettings_test.go
@@ -1,0 +1,189 @@
+package slashcmd
+
+import "testing"
+
+func TestDefaultOMPSkillSettingsEnablesEverything(t *testing.T) {
+	s := defaultOMPSkillSettings()
+	if !s.enabled || !s.enableSkillCommands || !s.enableCodexUser || !s.enableClaudeUser ||
+		!s.enableClaudeProject || !s.enablePiUser || !s.enablePiProject ||
+		!s.enableAgentsUser || !s.enableAgentsProject {
+		t.Fatalf("expected every toggle enabled by default, got %+v", s)
+	}
+	if len(s.customDirectories) != 0 || len(s.ignoredSkills) != 0 || len(s.includeSkills) != 0 {
+		t.Fatalf("expected empty lists by default, got %+v", s)
+	}
+	if !s.allows("anything") {
+		t.Fatal("default settings must allow every skill name")
+	}
+}
+
+func TestParseOMPSkillSettingsBooleans(t *testing.T) {
+	s := defaultOMPSkillSettings()
+	parseOMPSkillSettings([]byte(`skills:
+  enableClaudeUser: false
+  enableCodexUser: "FALSE"
+  enableAgentsUser: no
+  enablePiProject: TRUE
+`), &s)
+	if s.enableClaudeUser {
+		t.Error("enableClaudeUser should be false")
+	}
+	if s.enableCodexUser {
+		t.Error("quoted FALSE should disable enableCodexUser")
+	}
+	if !s.enableAgentsUser {
+		t.Error("an unrecognised scalar must leave the key at its default")
+	}
+	if !s.enablePiProject {
+		t.Error("TRUE should enable enablePiProject")
+	}
+}
+
+func TestParseOMPSkillSettingsIgnoresOtherSections(t *testing.T) {
+	s := defaultOMPSkillSettings()
+	parseOMPSkillSettings([]byte(`commands:
+  enableClaudeUser: false
+  enableClaudeProject: false
+retry:
+  fallbackChains:
+    default:
+      - anthropic/claude-fable-5
+skills:
+  enableClaudeProject: false
+`), &s)
+	if !s.enableClaudeUser {
+		t.Error("commands.enableClaudeUser must not affect skills settings")
+	}
+	if s.enableClaudeProject {
+		t.Error("skills.enableClaudeProject should be false")
+	}
+}
+
+func TestParseOMPSkillSettingsBlockLists(t *testing.T) {
+	s := defaultOMPSkillSettings()
+	parseOMPSkillSettings([]byte(`skills:
+  customDirectories:
+    - ~/.omp/profiles/personal/agent/skills
+    - "/opt/skills"
+  ignoredSkills:
+    - noisy-*
+  enablePiUser: false
+`), &s)
+	if len(s.customDirectories) != 2 ||
+		s.customDirectories[0] != "~/.omp/profiles/personal/agent/skills" ||
+		s.customDirectories[1] != "/opt/skills" {
+		t.Fatalf("unexpected customDirectories: %#v", s.customDirectories)
+	}
+	if len(s.ignoredSkills) != 1 || s.ignoredSkills[0] != "noisy-*" {
+		t.Fatalf("unexpected ignoredSkills: %#v", s.ignoredSkills)
+	}
+	if s.enablePiUser {
+		t.Error("a key after a block list must still be parsed")
+	}
+	if s.allows("noisy-thing") {
+		t.Error("ignoredSkills glob should ban noisy-thing")
+	}
+	if !s.allows("quiet-thing") {
+		t.Error("unmatched name should remain allowed")
+	}
+}
+
+func TestParseOMPSkillSettingsFlowLists(t *testing.T) {
+	s := defaultOMPSkillSettings()
+	parseOMPSkillSettings([]byte(`skills:
+  includeSkills: [deploy, "review"]
+  customDirectories: []
+`), &s)
+	if len(s.includeSkills) != 2 || s.includeSkills[0] != "deploy" || s.includeSkills[1] != "review" {
+		t.Fatalf("unexpected includeSkills: %#v", s.includeSkills)
+	}
+	if len(s.customDirectories) != 0 {
+		t.Fatalf("empty flow list should clear the key: %#v", s.customDirectories)
+	}
+	if !s.allows("deploy") || s.allows("other") {
+		t.Error("includeSkills should act as an allow list")
+	}
+}
+
+func TestParseOMPSkillSettingsListsReplaceAcrossFiles(t *testing.T) {
+	s := defaultOMPSkillSettings()
+	parseOMPSkillSettings([]byte("skills:\n  ignoredSkills:\n    - a\n"), &s)
+	parseOMPSkillSettings([]byte("skills:\n  ignoredSkills:\n    - b\n"), &s)
+	if len(s.ignoredSkills) != 1 || s.ignoredSkills[0] != "b" {
+		t.Fatalf("later file must replace the list, got %#v", s.ignoredSkills)
+	}
+}
+
+func TestParseOMPSkillSettingsDisabledExtensions(t *testing.T) {
+	s := defaultOMPSkillSettings()
+	parseOMPSkillSettings([]byte(`disabledExtensions:
+  - skill:deploy
+  - plugin:foo
+  - agent:bar
+skills:
+  enabled: true
+`), &s)
+	if !s.disabledSkills["deploy"] {
+		t.Error("skill:deploy should be banned")
+	}
+	if len(s.disabledSkills) != 1 {
+		t.Fatalf("only skill: entries count, got %#v", s.disabledSkills)
+	}
+	if s.allows("deploy") {
+		t.Error("banned skill must not be allowed")
+	}
+	if !s.allows("foo") {
+		t.Error("plugin:foo must not ban a skill named foo")
+	}
+}
+
+func TestParseOMPSkillSettingsDisabledExtensionsFlowForm(t *testing.T) {
+	s := defaultOMPSkillSettings()
+	parseOMPSkillSettings([]byte("disabledExtensions: [skill:one, skill:two]\n"), &s)
+	if !s.disabledSkills["one"] || !s.disabledSkills["two"] {
+		t.Fatalf("flow form should be parsed, got %#v", s.disabledSkills)
+	}
+}
+
+func TestParseOMPSkillSettingsDisabledExtensionsUnderSkillsIsIgnored(t *testing.T) {
+	s := defaultOMPSkillSettings()
+	parseOMPSkillSettings([]byte("skills:\n  disabledExtensions:\n    - skill:deploy\n"), &s)
+	if len(s.disabledSkills) != 0 {
+		t.Fatalf("disabledExtensions is top level only, got %#v", s.disabledSkills)
+	}
+}
+
+func TestParseOMPSkillSettingsTabIndentationSkipped(t *testing.T) {
+	s := defaultOMPSkillSettings()
+	parseOMPSkillSettings([]byte("skills:\n\tenableClaudeUser: false\n"), &s)
+	if !s.enableClaudeUser {
+		t.Error("a tab-indented line must be skipped, leaving the default")
+	}
+}
+
+func TestParseOMPSkillSettingsTrailingCommentsAndSpaces(t *testing.T) {
+	s := defaultOMPSkillSettings()
+	parseOMPSkillSettings([]byte("skills: \n  enableClaudeUser: false # off on purpose\n"), &s)
+	if s.enableClaudeUser {
+		t.Error("trailing comment should not defeat boolean parsing")
+	}
+}
+
+func TestSourceFallbackEnabled(t *testing.T) {
+	s := defaultOMPSkillSettings()
+	if !s.sourceFallbackEnabled() {
+		t.Error("defaults should enable the fall-through gate")
+	}
+	s.enableCodexUser = false
+	s.enableClaudeUser = false
+	s.enableClaudeProject = false
+	s.enablePiUser = false
+	s.enablePiProject = false
+	if s.sourceFallbackEnabled() {
+		t.Error("all five toggles off should close the fall-through gate")
+	}
+	s.enableAgentsProject = true
+	if s.sourceFallbackEnabled() {
+		t.Error("agents toggles must not open the fall-through gate")
+	}
+}

--- a/internal/slashcmd/pi.go
+++ b/internal/slashcmd/pi.go
@@ -1,5 +1,12 @@
 package slashcmd
 
+import (
+	"encoding/json"
+	"path/filepath"
+
+	"github.com/0cv/herdr-mobile-relay/internal/agentroots"
+)
+
 type piProvider struct{}
 
 func (p *piProvider) ID() string { return "pi" }
@@ -31,14 +38,126 @@ var piBuiltins = []Command{
 	{"/quit", "Quit Pi", "builtin", ""},
 }
 
+// Discover reproduces Pi's own skill resolution: the skill directory of every
+// Pi agent profile plus ~/.agents/skills at user scope, and .pi/skills and
+// .agents/skills from the git root down to the cwd at project scope, rendered
+// as the /skill:<name> commands Pi registers.
+//
+// Sources are scanned in descending precedence with first-wins dedupe: project
+// scope before user scope, so the more specific scope wins a name collision,
+// and within each scope the brand directories (.pi, Pi's own agent dirs) before
+// the generic .agents ones, matching Pi's own resolution. Scanning the winners
+// first also spends the shared file budget on them, so exhaustion truncates the
+// least important skills.
+//
+// Pi's frontmatter disable-model-invocation suppresses model auto-invocation
+// only and explicitly keeps /skill:<name> working, so it is not a palette hide
+// and nothing here filters on it.
 func (p *piProvider) Discover(ctx DiscoverContext) ([]Command, bool) {
-	return builtinsWithGenericSkills(piBuiltins, ctx)
+	if ctx.CommandFormat != "" {
+		// The relay's INI configured this profile explicitly, which outranks
+		// discovery.
+		custom, truncated := discoverGenericSkills(ctx.SkillDirs, ctx.CommandFormat)
+		return builtinsWithCustom(piBuiltins, custom), truncated
+	}
+
+	if !piSkillCommandsEnabled(ctx.Home) {
+		builtins := make([]Command, len(piBuiltins))
+		copy(builtins, piBuiltins)
+		return builtins, false
+	}
+
+	truncated := false
+	budget := maxCustomFiles
+	active := make(map[string]Command, len(piBuiltins))
+	order := make([]string, 0, len(piBuiltins))
+	apply := func(commands []Command) {
+		for _, command := range commands {
+			if _, exists := active[command.Command]; exists {
+				continue
+			}
+			order = append(order, command.Command)
+			active[command.Command] = command
+		}
+	}
+	apply(piBuiltins)
+
+	scan := func(scope string, dirs ...string) {
+		for _, dir := range dirs {
+			if dir == "" {
+				continue
+			}
+			cmds, trunc := scanSkillDirFormat(dir, scope, ompCommandFormat, &budget)
+			apply(cmds)
+			truncated = truncated || trunc
+		}
+	}
+
+	// findProjectDirs lists ancestors outermost first with stems in argument
+	// order, so the stems are passed lowest precedence first and the flat list
+	// is walked backwards: innermost ancestor first, .pi before .agents within
+	// one ancestor.
+	projectDirs := findProjectDirs(ctx.Cwd, []string{".agents", ".pi"})
+	for i := len(projectDirs) - 1; i >= 0; i-- {
+		scan("project", filepath.Join(projectDirs[i], "skills"))
+	}
+
+	scan("personal", agentroots.PiSkillDirs(ctx.Home)...)
+	scan("personal", filepath.Join(ctx.Home, ".agents", "skills"))
+
+	commands := make([]Command, 0, len(order))
+	for _, name := range order {
+		if command, exists := active[name]; exists {
+			commands = append(commands, command)
+		}
+	}
+	if budget <= 0 {
+		truncated = true
+	}
+	return commands, truncated
 }
 
-func builtinsWithGenericSkills(builtins []Command, ctx DiscoverContext) ([]Command, bool) {
-	custom, truncated := discoverGenericSkills(ctx.SkillDirs, ctx.CommandFormat)
+// piSkillSettings is the slice of Pi's settings.json the palette depends on. The
+// pointer distinguishes an absent key from an explicit false.
+type piSkillSettings struct {
+	EnableSkillCommands *bool `json:"enableSkillCommands"`
+}
+
+// piSkillCommandsEnabled reports whether Pi registers skills as /skill:<name>
+// commands. The first settings.json found across Pi's agent directories
+// decides; where several profiles exist the relay cannot know which one the
+// pane runs, so first-found wins - the search stops at the first directory
+// containing a settings.json even when that file cannot be read, because
+// falling through would apply an unrelated profile's settings. An absent,
+// unreadable or unparsable file leaves Pi's documented default of true, because
+// failing open can only show a command the user could have run, never hide one.
+func piSkillCommandsEnabled(home string) bool {
+	for _, dir := range agentroots.PiConfigDirs(home) {
+		data, found, ok := settingsFileIn(dir, "settings.json")
+		if !found {
+			continue
+		}
+		if !ok {
+			return true
+		}
+		var settings piSkillSettings
+		if err := json.Unmarshal(data, &settings); err != nil {
+			return true
+		}
+		if settings.EnableSkillCommands != nil {
+			return *settings.EnableSkillCommands
+		}
+		return true
+	}
+	return true
+}
+
+// builtinsWithCustom appends custom commands to builtins, keeping the builtin on
+// a name collision. Used for the INI-configured escape hatch, where the relay's
+// own configuration named the skill directories explicitly.
+func builtinsWithCustom(builtins, custom []Command) []Command {
 	if len(custom) == 0 {
-		return builtins, truncated
+		return builtins
 	}
 
 	commands := make([]Command, 0, len(builtins)+len(custom))
@@ -54,7 +173,7 @@ func builtinsWithGenericSkills(builtins []Command, ctx DiscoverContext) ([]Comma
 		seen[command.Command] = true
 		commands = append(commands, command)
 	}
-	return commands, truncated
+	return commands
 }
 
 func init() {

--- a/internal/slashcmd/pi_test.go
+++ b/internal/slashcmd/pi_test.go
@@ -1,9 +1,14 @@
 package slashcmd
 
-import "testing"
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
 
 func TestPiBuiltinCatalog(t *testing.T) {
-	catalog := CatalogForProfile("pi", "pi", "/tmp", "/nonexistent", nil, "", "0.82.1")
+	isolateAgentEnv(t)
+	catalog := CatalogForProfile("pi", "pi", t.TempDir(), "/nonexistent", nil, "", "0.82.1")
 	if catalog.Truncated {
 		t.Fatal("builtins-only catalog is truncated")
 	}
@@ -22,5 +27,247 @@ func TestPiBuiltinCatalog(t *testing.T) {
 		if command.Description == "" {
 			t.Errorf("%s has no description", command.Command)
 		}
+	}
+}
+
+// piFixture builds an isolated home + repo pair for Pi discovery tests.
+type piFixture struct {
+	home string
+	repo string
+}
+
+func newPiFixture(t *testing.T) piFixture {
+	t.Helper()
+	isolateAgentEnv(t)
+	root := t.TempDir()
+	fixture := piFixture{
+		home: filepath.Join(root, "home"),
+		repo: filepath.Join(root, "repo"),
+	}
+	mkdirAll(t, filepath.Join(fixture.home, ".pi", "agent"))
+	mkdirAll(t, fixture.repo)
+	return fixture
+}
+
+func (f piFixture) gitRepo(t *testing.T) {
+	t.Helper()
+	mkdirAll(t, filepath.Join(f.repo, ".git"))
+}
+
+func (f piFixture) catalog(cwd string) Catalog {
+	return CatalogForProfile("pi", "pi", cwd, f.home, nil, "", "0.82.1")
+}
+
+func TestPiDiscoversProjectPiSkills(t *testing.T) {
+	f := newPiFixture(t)
+	f.gitRepo(t)
+	writeSkill(t, filepath.Join(f.repo, ".pi", "skills"), "deploy", "Ship the service")
+
+	command, ok := commandByName(f.catalog(f.repo), "/skill:deploy")
+	if !ok {
+		t.Fatal("/skill:deploy missing from the Pi catalog")
+	}
+	if command.Source != "project" {
+		t.Errorf("source = %q, want project", command.Source)
+	}
+	if command.Description != "Ship the service" {
+		t.Errorf("description = %q", command.Description)
+	}
+}
+
+func TestPiDiscoversProjectSkillsFromSubdirectory(t *testing.T) {
+	f := newPiFixture(t)
+	f.gitRepo(t)
+	writeSkill(t, filepath.Join(f.repo, ".pi", "skills"), "deploy", "Ship the service")
+	nested := filepath.Join(f.repo, "services", "api")
+	mkdirAll(t, nested)
+
+	if _, ok := commandByName(f.catalog(nested), "/skill:deploy"); !ok {
+		t.Fatal("walk-up from a subdirectory did not reach the git root's .pi/skills")
+	}
+}
+
+func TestPiDiscoversProjectAgentsSkills(t *testing.T) {
+	f := newPiFixture(t)
+	f.gitRepo(t)
+	writeSkill(t, filepath.Join(f.repo, ".agents", "skills"), "shared", "Shared across agents")
+
+	command, ok := commandByName(f.catalog(f.repo), "/skill:shared")
+	if !ok {
+		t.Fatal("Pi must discover a project .agents/skills directory")
+	}
+	if command.Source != "project" {
+		t.Errorf("source = %q, want project", command.Source)
+	}
+}
+
+func TestPiDiscoversUserSkillsFromAgentDir(t *testing.T) {
+	f := newPiFixture(t)
+	writeSkill(t, filepath.Join(f.home, ".pi", "agent", "skills"), "mine", "My own skill")
+
+	command, ok := commandByName(f.catalog(f.repo), "/skill:mine")
+	if !ok {
+		t.Fatal("Pi must discover its own agent skills directory")
+	}
+	if command.Source != "personal" {
+		t.Errorf("source = %q, want personal", command.Source)
+	}
+}
+
+func TestPiDiscoversUserAgentsSkills(t *testing.T) {
+	f := newPiFixture(t)
+	writeSkill(t, filepath.Join(f.home, ".agents", "skills"), "generic", "Generic user skill")
+
+	command, ok := commandByName(f.catalog(f.repo), "/skill:generic")
+	if !ok {
+		t.Fatal("Pi must discover ~/.agents/skills")
+	}
+	if command.Source != "personal" {
+		t.Errorf("source = %q, want personal", command.Source)
+	}
+}
+
+func TestPiDiscoversUserSkillsFromProfileAgentDir(t *testing.T) {
+	f := newPiFixture(t)
+	writeSkill(t, filepath.Join(f.home, ".pi", "profiles", "personal", "agent", "skills"),
+		"prof", "From a named profile")
+
+	command, ok := commandByName(f.catalog(f.repo), "/skill:prof")
+	if !ok {
+		t.Fatal("a named profile's skills must be discovered")
+	}
+	if command.Source != "personal" {
+		t.Errorf("source = %q, want personal", command.Source)
+	}
+}
+
+func TestPiSkillCommandsDisabledYieldsBuiltinsOnly(t *testing.T) {
+	f := newPiFixture(t)
+	f.gitRepo(t)
+	writeSkill(t, filepath.Join(f.repo, ".pi", "skills"), "deploy", "Ship the service")
+	writeFile(t, filepath.Join(f.home, ".pi", "agent", "settings.json"),
+		"{\"enableSkillCommands\": false}\n")
+
+	catalog := f.catalog(f.repo)
+	if len(catalog.Commands) != len(piBuiltins) {
+		t.Fatalf("commands = %d, want %d builtins", len(catalog.Commands), len(piBuiltins))
+	}
+	if countSource(catalog, "builtin") != len(piBuiltins) {
+		t.Error("every command should be a builtin")
+	}
+}
+
+func TestPiMalformedSettingsFailsOpen(t *testing.T) {
+	f := newPiFixture(t)
+	f.gitRepo(t)
+	writeSkill(t, filepath.Join(f.repo, ".pi", "skills"), "deploy", "Ship the service")
+	writeFile(t, filepath.Join(f.home, ".pi", "agent", "settings.json"), "{not json")
+
+	if _, ok := commandByName(f.catalog(f.repo), "/skill:deploy"); !ok {
+		t.Fatal("an unparsable settings.json must leave skill commands registered")
+	}
+}
+
+func TestPiAbsentSettingsRegistersSkills(t *testing.T) {
+	f := newPiFixture(t)
+	f.gitRepo(t)
+	writeSkill(t, filepath.Join(f.repo, ".pi", "skills"), "deploy", "Ship the service")
+
+	if _, ok := commandByName(f.catalog(f.repo), "/skill:deploy"); !ok {
+		t.Fatal("without settings.json Pi's documented default registers skill commands")
+	}
+}
+
+func TestPiProjectSkillBeatsUserSkill(t *testing.T) {
+	f := newPiFixture(t)
+	f.gitRepo(t)
+	writeSkill(t, filepath.Join(f.home, ".pi", "agent", "skills"), "deploy", "user description")
+	writeSkill(t, filepath.Join(f.repo, ".pi", "skills"), "deploy", "project description")
+
+	catalog := f.catalog(f.repo)
+	seen := 0
+	for _, command := range catalog.Commands {
+		if command.Command == "/skill:deploy" {
+			seen++
+		}
+	}
+	if seen != 1 {
+		t.Fatalf("/skill:deploy appears %d times, want 1", seen)
+	}
+	command, _ := commandByName(catalog, "/skill:deploy")
+	if command.Description != "project description" || command.Source != "project" {
+		t.Fatalf("project scope should win, got %+v", command)
+	}
+}
+
+func TestPiDropsSkillWithoutDescription(t *testing.T) {
+	f := newPiFixture(t)
+	f.gitRepo(t)
+	writeSkill(t, filepath.Join(f.repo, ".pi", "skills"), "nodesc", "")
+
+	if _, ok := commandByName(f.catalog(f.repo), "/skill:nodesc"); ok {
+		t.Fatal("a skill without a description must not be listed")
+	}
+}
+
+func TestPiINIConfiguredFormatSkipsNativeDiscovery(t *testing.T) {
+	f := newPiFixture(t)
+	f.gitRepo(t)
+	writeSkill(t, filepath.Join(f.repo, ".pi", "skills"), "deploy", "Ship the service")
+	explicit := filepath.Join(f.home, "explicit", "skills")
+	writeSkill(t, explicit, "explicit-one", "Explicitly configured")
+
+	catalog := CatalogForProfile("pi", "pi", f.repo, f.home,
+		[]string{explicit}, "skill:{name}", "0.82.1")
+	if _, ok := commandByName(catalog, "/skill:explicit-one"); !ok {
+		t.Error("the INI-configured directory must be scanned")
+	}
+	if _, ok := commandByName(catalog, "/skill:deploy"); ok {
+		t.Error("explicit configuration outranks discovery, so native discovery is skipped")
+	}
+}
+
+func TestPiBrandBeatsGenericAtUserScope(t *testing.T) {
+	f := newPiFixture(t)
+	writeSkill(t, filepath.Join(f.home, ".pi", "agent", "skills"), "deploy", "Brand copy")
+	writeSkill(t, filepath.Join(f.home, ".agents", "skills"), "deploy", "Generic copy")
+
+	command, ok := commandByName(f.catalog(f.repo), "/skill:deploy")
+	if !ok {
+		t.Fatal("/skill:deploy missing")
+	}
+	if command.Description != "Brand copy" {
+		t.Errorf("description = %q, want the brand copy: Pi's own agent directories outrank ~/.agents",
+			command.Description)
+	}
+}
+
+func TestPiBrandBeatsGenericAtProjectScope(t *testing.T) {
+	f := newPiFixture(t)
+	f.gitRepo(t)
+	writeSkill(t, filepath.Join(f.repo, ".pi", "skills"), "deploy", "Brand copy")
+	writeSkill(t, filepath.Join(f.repo, ".agents", "skills"), "deploy", "Generic copy")
+
+	command, ok := commandByName(f.catalog(f.repo), "/skill:deploy")
+	if !ok {
+		t.Fatal("/skill:deploy missing")
+	}
+	if command.Description != "Brand copy" {
+		t.Errorf("description = %q, want the brand copy: .pi outranks .agents within one ancestor",
+			command.Description)
+	}
+}
+
+func TestPiUnusableSettingsStopsAtFirstConfigDir(t *testing.T) {
+	f := newPiFixture(t)
+	f.gitRepo(t)
+	writeSkill(t, filepath.Join(f.repo, ".pi", "skills"), "deploy", "Ship the service")
+	writeFile(t, filepath.Join(f.home, ".pi", "profiles", "personal", "agent", "settings.json"),
+		strings.Repeat(" ", maxSettingsSize+1))
+	writeFile(t, filepath.Join(f.home, ".pi", "agent", "settings.json"),
+		"{\"enableSkillCommands\": false}\n")
+
+	if _, ok := commandByName(f.catalog(f.repo), "/skill:deploy"); !ok {
+		t.Fatal("first-found wins: an unusable settings.json in the first agent directory must stop the search and fail open, not fall through to another profile's settings")
 	}
 }

--- a/internal/slashcmd/projectdirs.go
+++ b/internal/slashcmd/projectdirs.go
@@ -1,0 +1,65 @@
+package slashcmd
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// findProjectDirs returns every existing <ancestor>/<stem> directory between the
+// git root and cwd, outermost first, and in stem order within one ancestor.
+// Without a git root only cwd is examined. Directories are de-duplicated.
+//
+// os.Stat is used rather than DirEntry.IsDir so a symlinked directory is
+// followed; symlinking an agent config tree out of a dotfiles repo is common.
+func findProjectDirs(cwd string, stems []string) []string {
+	if cwd == "" || len(stems) == 0 {
+		return nil
+	}
+	var dirs []string
+	seen := make(map[string]bool)
+
+	appendStems := func(dir string, out *[]string) {
+		for _, stem := range stems {
+			candidate := filepath.Join(dir, stem)
+			if seen[candidate] {
+				continue
+			}
+			if info, err := os.Stat(candidate); err == nil && info.IsDir() {
+				*out = append(*out, candidate)
+				seen[candidate] = true
+			}
+		}
+	}
+
+	gitRoot := findGitRoot(cwd)
+	if gitRoot == "" {
+		appendStems(cwd, &dirs)
+		return dirs
+	}
+
+	appendStems(gitRoot, &dirs)
+
+	// Walk from cwd upward to the git root, then reverse so the outermost scope
+	// comes first (git root direction).
+	var chain [][]string
+	dir := cwd
+	for range maxGitWalkDepth {
+		var level []string
+		appendStems(dir, &level)
+		if len(level) > 0 {
+			chain = append(chain, level)
+		}
+		if dir == gitRoot {
+			break
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	for i := len(chain) - 1; i >= 0; i-- {
+		dirs = append(dirs, chain[i]...)
+	}
+	return dirs
+}

--- a/internal/slashcmd/qoder.go
+++ b/internal/slashcmd/qoder.go
@@ -1,7 +1,6 @@
 package slashcmd
 
 import (
-	"os"
 	"path/filepath"
 )
 
@@ -36,7 +35,7 @@ func (p *qoderProvider) Discover(ctx DiscoverContext) ([]Command, bool) {
 	var projectScopes []qoderProjectScope
 
 	if ctx.Cwd != "" {
-		projectDirs := findQoderProjectDirs(ctx.Cwd)
+		projectDirs := findProjectDirs(ctx.Cwd, []string{".qoder"})
 		for _, dir := range projectDirs {
 			cmdDir := filepath.Join(dir, "commands")
 			projectCmds, commandSuppressions, trunc := walkCommandDirBudget(cmdDir, "project", &budget)
@@ -188,50 +187,6 @@ func filterQoderCommands(commands []Command, suppressed map[string]bool) []Comma
 		}
 	}
 	return filtered
-}
-
-// findQoderProjectDirs returns all .qoder directories from git root through cwd.
-// Without a git root, only cwd/.qoder is checked.
-func findQoderProjectDirs(cwd string) []string {
-	var dirs []string
-	seen := make(map[string]bool)
-
-	gitRoot := findGitRoot(cwd)
-	if gitRoot == "" {
-		candidate := filepath.Join(cwd, ".qoder")
-		if info, err := os.Stat(candidate); err == nil && info.IsDir() {
-			dirs = append(dirs, candidate)
-		}
-		return dirs
-	}
-
-	candidate := filepath.Join(gitRoot, ".qoder")
-	if info, err := os.Stat(candidate); err == nil && info.IsDir() {
-		dirs = append(dirs, candidate)
-		seen[candidate] = true
-	}
-
-	var chain []string
-	dir := cwd
-	for depth := 0; depth < maxGitWalkDepth; depth++ {
-		candidate := filepath.Join(dir, ".qoder")
-		if info, err := os.Stat(candidate); err == nil && info.IsDir() && !seen[candidate] {
-			chain = append(chain, candidate)
-			seen[candidate] = true
-		}
-		if dir == gitRoot {
-			break
-		}
-		parent := filepath.Dir(dir)
-		if parent == dir {
-			break
-		}
-		dir = parent
-	}
-	for i := len(chain) - 1; i >= 0; i-- {
-		dirs = append(dirs, chain[i])
-	}
-	return dirs
 }
 
 func init() {

--- a/internal/slashcmd/testenv_test.go
+++ b/internal/slashcmd/testenv_test.go
@@ -1,0 +1,23 @@
+package slashcmd
+
+import "testing"
+
+// isolateAgentEnv neutralises every environment variable that agentroots reads
+// from the process environment, so a developer's own agent configuration cannot
+// change what a test discovers. resolve trims and discards empty values, so an
+// empty variable is equivalent to an unset one.
+func isolateAgentEnv(t *testing.T) {
+	t.Helper()
+	for _, name := range []string{
+		"PI_CODING_AGENT_DIR",
+		"HERDR_OMP_CONFIG_DIRS",
+		"HERDR_PI_CONFIG_DIRS",
+		"HERDR_CLAUDE_CONFIG_DIRS",
+		"HERDR_QODER_CONFIG_DIRS",
+		"HERDR_CODEX_CONFIG_DIRS",
+		"CLAUDE_CONFIG_DIR",
+		"CODEX_HOME",
+	} {
+		t.Setenv(name, "")
+	}
+}

--- a/internal/slashcmd/walk.go
+++ b/internal/slashcmd/walk.go
@@ -188,6 +188,78 @@ func scanSkillDirBudget(dir, source string, budget *int) ([]Command, []string, b
 	return commands, suppressed, truncated
 }
 
+// scanSkillDirFormat scans dir for <entry>/SKILL.md and renders each skill
+// through format, which must contain exactly one "{name}". The skill name comes
+// from frontmatter "name", falling back to the directory name, matching how omp,
+// Pi and Kimi resolve it. Skills without a description are dropped, as those
+// agents require one. Reports whether budget ran out.
+//
+// Unlike scanSkillDirBudget this follows symlinked skill directories and
+// de-duplicates by real path, matching omp, and returns no suppression list:
+// none of omp, Pi or Kimi has a frontmatter field that hides a skill from the
+// command palette.
+func scanSkillDirFormat(dir, source, format string, budget *int) ([]Command, bool) {
+	if strings.Count(format, "{name}") != 1 {
+		return nil, false
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, false
+	}
+	var commands []Command
+	seen := make(map[string]bool, len(entries))
+	truncated := false
+	for _, e := range entries {
+		if *budget <= 0 {
+			truncated = true
+			break
+		}
+		if strings.HasPrefix(e.Name(), ".") {
+			continue
+		}
+		skillDir := filepath.Join(dir, e.Name())
+		if info, err := os.Stat(skillDir); err != nil || !info.IsDir() {
+			continue
+		}
+		skillFile := filepath.Join(skillDir, "SKILL.md")
+		info, err := os.Stat(skillFile)
+		if err != nil || !info.Mode().IsRegular() {
+			continue
+		}
+		real, err := filepath.EvalSymlinks(skillFile)
+		if err != nil {
+			real = skillFile
+		}
+		if seen[real] {
+			continue
+		}
+		seen[real] = true
+		*budget--
+		metadata, ok := readSkillMetadata(skillFile)
+		if !ok {
+			continue
+		}
+		name := metadata["name"]
+		if name == "" {
+			name = e.Name()
+		}
+		if !commandNamePattern.MatchString(name) {
+			continue
+		}
+		description := metadata["description"]
+		if description == "" {
+			continue
+		}
+		commands = append(commands, Command{
+			Command:      "/" + strings.TrimPrefix(strings.Replace(format, "{name}", name, 1), "/"),
+			Description:  compact(description, 240),
+			Source:       source,
+			ArgumentHint: compact(metadata["argument-hint"], 120),
+		})
+	}
+	return commands, truncated
+}
+
 func fileFrontmatter(path string) map[string]string {
 	data, err := os.ReadFile(path)
 	if err != nil || len(data) > maxMetadataSize {


### PR DESCRIPTION
The mobile slash-command palette listed repo-level skills for Claude and Qoder panes only.
An Oh My Pi pane listed **no** skills at all, a Pi pane listed one hardcoded home directory, and Kimi
panes listed none — because the palette only knew the skill directories named in the relay's own INI,
while each of these agents resolves skills from many directories of its own.

Every relay-supported pane now lists exactly the skills that agent would itself accept as a slash
command, discovered from the repo with **no relay configuration**, and honouring the bans that agent's
own configuration applies. An `.omp/skills/<name>/SKILL.md` in a repo shows up as `/skill:<name>` with
source `project` with nothing in the INI and no environment variables set; a skill the user has banned
in omp's own `config.yml` does not appear.

> [!IMPORTANT]
> **Stacked on #16.** This branch contains #16's six commits because it edits `internal/agentroots`,
> which #16 introduces. Please merge #16 first — GitHub will then shrink this diff to the six commits
> that are actually mine to review here (`refactor: fold the duplicated project-directory walks` and
> everything after it). I could not set #16's branch as this PR's base because that requires the base
> branch to exist in this repository, and I only have read access.

### Change, one commit per reviewable unit

| Commit | What |
|---|---|
| `refactor:` project-directory walks | `findClaudeProjectDirs` and `findQoderProjectDirs` were the same 40-line walk over different stems. One `findProjectDirs(cwd, stems)`. The Claude and Qoder tests are **unchanged**, which is what makes it a refactor. |
| `feat:` YAML block scalars | `description: \|` parsed to the literal value `"\|"`. Eleven skills on my machine rendered that way, and a one-character description also defeated the rule that drops skills without one. |
| `feat:` format-aware scanner + accessors | `scanSkillDirFormat` renders `/skill:<name>` where an agent namespaces them, follows symlinked skill trees, and de-dupes via `EvalSymlinks`. Skill/config directories exposed from the `agentroots` seam. |
| `feat:` Oh My Pi | Reproduces omp's thirteen sources in descending priority with first-wins, and honours omp's own toggles, `disabledExtensions`, `ignoredSkills` and `includeSkills` from `config.yml`, user-level then overlaid by repo-level `.omp` config. |
| `feat:` Pi | Discovers Pi's own roots: every Pi agent profile's skill directory plus brand and generic dirs, git root down to cwd, brand copy winning a collision. |
| `feat:` Kimi Code | Generic and brand candidate groups at user and project scope, per Kimi's published skills documentation. |

Two design points worth stating explicitly, because both are deliberate:

- **Fail open.** An unreadable or unparsable agent config registers the commands rather than hiding
  them. A missing command the user could have run is worse than an extra one.
- **The INI stays an escape hatch.** A pane with an explicitly configured skill directory or command
  format behaves exactly as before; native discovery is skipped for it. Pi's entries had to be removed
  from the resolver's default maps to make this work — a *default* format made the command config
  always report "configured", which pinned Pi to the INI path and made discovery unreachable.

### Verification

Fixture tests: `go test -count=1 ./internal/slashcmd/... ./internal/profiles/... ./internal/agentroots/...`
green. `gofmt -l internal` empty, `go vet ./...` clean. No dependency changes — `go.mod`/`go.sum` untouched.

Verified against real installations too, with every agent environment variable unset:

- A repo with nine `.omp/skills` entries plus five `customDirectories` reports 82 commands = 68 builtins
  + 9 `project` + 5 `personal`, and **zero** entries from `~/.claude/skills` (40 skills present),
  `~/.codex/skills` or `~/.agents/skills` — because that machine's `config.yml` sets
  `enableClaudeUser`/`enableCodexUser`/`enableAgentsUser: false`. That is the falsifiable part: the bans
  are read, not guessed. This repo also has no `.git`, so it exercises the no-git-root path.
- A second repo reports 15 `project` entries (8 `.claude` + 7 `.agents`), matching what is on disk.
- Codex and OpenCode panes report builtins only, unchanged — this PR adds discovery for omp, Pi and Kimi.

### Known limitations, disclosed rather than hidden

- **Budget.** One shared `maxCustomFiles` budget spans all sources. It is now spent highest-priority-first,
  so exhaustion truncates only low-priority sources; before this PR's last revision it dropped the
  *winners*. A repo with >250 skills still truncates, and the palette reports `truncated`.
- **`CommandFormat` is honoured by omp, Pi and Kimi only.** Claude, Qoder, Codex and OpenCode ignore it.
  Pre-existing (`grep -c CommandFormat` is 0 for all four on `main`), not introduced here, but it does mean
  the package carries two conventions.
- **Kimi flat `.md` skills.** Kimi also recognises a bare `<name>.md` and falls back to the body's first
  line for a description; the shared scanner requires `<name>/SKILL.md` and a real description, so Kimi is
  under-reported there. Deliberate: the direction of error is hiding a working command, never showing a
  broken one.

### Scope

`internal/slashcmd` (three new files, six modified), `internal/profiles/resolver.go`,
`internal/agentroots/agentroots.go`. Independent of #15.