### PR TITLE
fix: preserve wrapped setup link targets

### DIFF
--- a/relay/common.sh
+++ b/relay/common.sh
@@ -1529,6 +1529,53 @@ record_phone_app_origin() {
     )
 }
 
+# Terminal control sequences belong only on an interactive stdout. Kept small so
+# tests can model a terminal without allocating a pseudo-terminal.
+stdout_is_terminal() {
+    [ -t 1 ]
+}
+
+# The setup URL reaches both the QR encoder and the terminal escape sink. Reject
+# control bytes first, then require an HTTPS origin or the normalizer's exact
+# canonical spelling of a loopback HTTP origin.
+phone_setup_url_is_safe() {
+    local url="$1"
+    local scheme
+    local remainder
+    local authority
+    local origin
+    local normalized
+    local binary
+
+    case "$url" in
+        *[[:cntrl:]]*)
+            return 1
+            ;;
+        https://*)
+            scheme=https
+            ;;
+        http://*)
+            scheme=http
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+
+    remainder="${url#*://}"
+    authority="${remainder%%[/?#]*}"
+    [ -n "$authority" ] || return 1
+    origin="$scheme://$authority"
+
+    if ! binary="$(relay_binary)"; then
+        return 1
+    fi
+    if ! normalized="$("$binary" normalize-origin --allow-loopback-http "$origin" 2>/dev/null)"; then
+        return 1
+    fi
+    [ "$scheme" = https ] || [ "$normalized" = "$origin" ]
+}
+
 # Prints an indented terminal QR code for the URL, or nothing when it cannot
 # be drawn because the terminal is too narrow. A wrapped QR is worse than the
 # plain link.
@@ -1543,10 +1590,14 @@ render_setup_qr() {
 }
 
 # Shared tail of quick-start and setup-link output: QR code when possible,
-# always the link.
+# always the link. Invalid values fail before either output sink sees them.
 print_phone_setup() {
     local phone_url="$1"
     local qr_code
+
+    if ! phone_setup_url_is_safe "$phone_url"; then
+        return 1
+    fi
     qr_code="$(render_setup_qr "$phone_url")"
     if [ -n "$qr_code" ]; then
         echo "  Scan this QR code with your phone camera:"
@@ -1559,7 +1610,13 @@ print_phone_setup() {
     else
         echo "  Open this private setup link on your phone:"
     fi
-    echo "  $phone_url"
+    if stdout_is_terminal &&
+       [ -z "${NO_COLOR+x}" ] &&
+       [ "${TERM:-}" != dumb ]; then
+        printf '  \033]8;;%s\033\\%s\033]8;;\033\\\n' "$phone_url" "$phone_url"
+    else
+        printf '  %s\n' "$phone_url"
+    fi
 }
 
 require_supported_platform() {

--- a/relay/common.sh
+++ b/relay/common.sh
@@ -1589,12 +1589,31 @@ render_setup_qr() {
     "$(relay_binary)" qr --columns "${cols:-80}" "$url" 2>/dev/null || true
 }
 
+# Prints one setup URL only after validating it. OSC 8 is limited to an
+# interactive, capable terminal; redirected and opted-out output stays plain.
+print_phone_setup_url() {
+    local phone_url="$1"
+
+    if ! phone_setup_url_is_safe "$phone_url"; then
+        return 1
+    fi
+    if stdout_is_terminal &&
+       [ -z "${NO_COLOR+x}" ] &&
+       [ "${TERM:-}" != dumb ]; then
+        printf '  \033]8;;%s\033\\%s\033]8;;\033\\\n' "$phone_url" "$phone_url"
+    else
+        printf '  %s\n' "$phone_url"
+    fi
+}
+
 # Shared tail of quick-start and setup-link output: QR code when possible,
 # always the link. Invalid values fail before either output sink sees them.
 print_phone_setup() {
     local phone_url="$1"
     local qr_code
 
+    # Reject before QR rendering. The output helper validates again so direct
+    # callers receive the same guarantee.
     if ! phone_setup_url_is_safe "$phone_url"; then
         return 1
     fi
@@ -1610,13 +1629,7 @@ print_phone_setup() {
     else
         echo "  Open this private setup link on your phone:"
     fi
-    if stdout_is_terminal &&
-       [ -z "${NO_COLOR+x}" ] &&
-       [ "${TERM:-}" != dumb ]; then
-        printf '  \033]8;;%s\033\\%s\033]8;;\033\\\n' "$phone_url" "$phone_url"
-    else
-        printf '  %s\n' "$phone_url"
-    fi
+    print_phone_setup_url "$phone_url"
 }
 
 require_supported_platform() {

--- a/relay/setup-link.sh
+++ b/relay/setup-link.sh
@@ -75,7 +75,7 @@ print_phone_setup "$PHONE_URL"
 if [ "$PHONE_URL" != "$DIRECT_URL" ]; then
     echo ""
     echo "  Direct browser fallback:"
-    echo "  $DIRECT_URL"
+    print_phone_setup_url "$DIRECT_URL"
 fi
 echo ""
 echo "  The relay and tunnel must be running for the link to work:"

--- a/relay/start.sh
+++ b/relay/start.sh
@@ -196,7 +196,7 @@ elif command -v cloudflared >/dev/null 2>&1; then
     if [ "$PHONE_URL" != "$DIRECT_URL" ]; then
         echo ""
         echo "  Direct browser fallback:"
-        echo "  $DIRECT_URL"
+        print_phone_setup_url "$DIRECT_URL"
     fi
     echo ""
     echo "  The phone app and relay are both served by this tunnel."

--- a/tests/test_common.sh
+++ b/tests/test_common.sh
@@ -130,6 +130,114 @@ test "$(HOME="$NODE_HOME" NVM_DIR="$NODE_HOME/.nvm" PATH=/usr/bin:/bin node_bin_
 test "$(NO_COLOR= menu_item 3 "Stable Tunnel")" = "  3. Stable Tunnel"
 test "$(NO_COLOR=1 menu_item q "Exit, change nothing")" = "  q. Exit, change nothing"
 
+# The setup-link sink asks the same compiled normalizer that created the app
+# origin. This fixture keeps the output tests isolated from an installed release.
+PHONE_SETUP_NORMALIZER="$WORK_DIR/phone-setup-normalizer"
+cat > "$PHONE_SETUP_NORMALIZER" <<'EOF'
+#!/bin/sh
+test "$1" = "normalize-origin" || exit 2
+test "$2" = "--allow-loopback-http" || exit 2
+case "$3" in
+    'http://127.0.0.1:8375 ')
+        printf '%s\n' 'http://127.0.0.1:8375'
+        ;;
+    https://app.example.test | http://127.0.0.1:8375)
+        printf '%s\n' "$3"
+        ;;
+    *)
+        exit 1
+        ;;
+esac
+EOF
+chmod 700 "$PHONE_SETUP_NORMALIZER"
+
+PHONE_SETUP_URL='https://app.example.test/#setup=relay%3A%2F%2Fmachine.example.test%3A443%3Ftoken%3Dfixture-private-token-0123456789abcdef'
+PHONE_SETUP_OPEN="$(printf '\033]8;;%s\033\\' "$PHONE_SETUP_URL")"
+PHONE_SETUP_CLOSE="$(printf '\033]8;;\033\\')"
+PHONE_SETUP_PLAIN_EXPECTED="$WORK_DIR/phone-setup-plain-expected"
+PHONE_SETUP_LINK_EXPECTED="$WORK_DIR/phone-setup-link-expected"
+PHONE_SETUP_ACTUAL="$WORK_DIR/phone-setup-actual"
+printf '  Open this private setup link on your phone:\n  %s\n' \
+    "$PHONE_SETUP_URL" > "$PHONE_SETUP_PLAIN_EXPECTED"
+printf '  Open this private setup link on your phone:\n  %s%s%s\n' \
+    "$PHONE_SETUP_OPEN" "$PHONE_SETUP_URL" "$PHONE_SETUP_CLOSE" > "$PHONE_SETUP_LINK_EXPECTED"
+
+# Redirected output stays byte-for-byte plain.
+(
+    relay_binary() { printf '%s\n' "$PHONE_SETUP_NORMALIZER"; }
+    render_setup_qr() { :; }
+    print_phone_setup "$PHONE_SETUP_URL"
+) > "$PHONE_SETUP_ACTUAL"
+cmp -s "$PHONE_SETUP_PLAIN_EXPECTED" "$PHONE_SETUP_ACTUAL"
+
+# A capable terminal gets one exact OSC 8 link around the complete visible URL.
+(
+    relay_binary() { printf '%s\n' "$PHONE_SETUP_NORMALIZER"; }
+    render_setup_qr() { :; }
+    stdout_is_terminal() { return 0; }
+    unset NO_COLOR
+    TERM=xterm-256color print_phone_setup "$PHONE_SETUP_URL"
+) > "$PHONE_SETUP_ACTUAL"
+cmp -s "$PHONE_SETUP_LINK_EXPECTED" "$PHONE_SETUP_ACTUAL"
+
+# User and terminal capability opt-outs override the TTY result.
+(
+    relay_binary() { printf '%s\n' "$PHONE_SETUP_NORMALIZER"; }
+    render_setup_qr() { :; }
+    stdout_is_terminal() { return 0; }
+    NO_COLOR=1 TERM=xterm-256color print_phone_setup "$PHONE_SETUP_URL"
+) > "$PHONE_SETUP_ACTUAL"
+cmp -s "$PHONE_SETUP_PLAIN_EXPECTED" "$PHONE_SETUP_ACTUAL"
+(
+    relay_binary() { printf '%s\n' "$PHONE_SETUP_NORMALIZER"; }
+    render_setup_qr() { :; }
+    stdout_is_terminal() { return 0; }
+    NO_COLOR= TERM=xterm-256color print_phone_setup "$PHONE_SETUP_URL"
+) > "$PHONE_SETUP_ACTUAL"
+cmp -s "$PHONE_SETUP_PLAIN_EXPECTED" "$PHONE_SETUP_ACTUAL"
+(
+    relay_binary() { printf '%s\n' "$PHONE_SETUP_NORMALIZER"; }
+    render_setup_qr() { :; }
+    stdout_is_terminal() { return 0; }
+    unset NO_COLOR
+    TERM=dumb print_phone_setup "$PHONE_SETUP_URL"
+) > "$PHONE_SETUP_ACTUAL"
+cmp -s "$PHONE_SETUP_PLAIN_EXPECTED" "$PHONE_SETUP_ACTUAL"
+
+# Normalized loopback HTTP remains valid, but untrusted values fail before the
+# QR or terminal sink and cannot place any attacker-controlled bytes on stdout.
+(
+    relay_binary() { printf '%s\n' "$PHONE_SETUP_NORMALIZER"; }
+    phone_setup_url_is_safe 'http://127.0.0.1:8375/#setup=fixture'
+)
+assert_phone_setup_rejected() {
+    local name="$1"
+    local url="$2"
+    local actual="$WORK_DIR/phone-setup-rejected-$name"
+
+    if (
+        relay_binary() { printf '%s\n' "$PHONE_SETUP_NORMALIZER"; }
+        render_setup_qr() { printf 'attacker-controlled QR\n'; }
+        stdout_is_terminal() { return 0; }
+        unset NO_COLOR
+        TERM=xterm-256color print_phone_setup "$url"
+    ) > "$actual" 2>/dev/null; then
+        echo "phone setup accepted unsafe $name URL" >&2
+        exit 1
+    fi
+    if [ -s "$actual" ]; then
+        echo "phone setup printed unsafe $name URL" >&2
+        exit 1
+    fi
+}
+assert_phone_setup_rejected bell "${PHONE_SETUP_URL}"$'\a''bell'
+assert_phone_setup_rejected esc-st "${PHONE_SETUP_URL}"$'\033\\''escape'
+assert_phone_setup_rejected carriage-return "${PHONE_SETUP_URL}"$'\r''return'
+assert_phone_setup_rejected line-feed "${PHONE_SETUP_URL}"$'\n''line'
+assert_phone_setup_rejected scheme 'javascript:alert(1)'
+assert_phone_setup_rejected non-loopback-http 'http://example.test/#setup=fixture'
+assert_phone_setup_rejected canonicalized-loopback-http 'http://127.0.0.1:8375 /#setup=fixture'
+
 # Once a shared app is configured, numeric choice 1 must keep it. The previous
 # implicit Enter-only default made the surrounding menu's usual "1" habit
 # silently switch the QR back to this relay.

--- a/tests/test_common.sh
+++ b/tests/test_common.sh
@@ -8,6 +8,18 @@ trap 'rm -rf "$WORK_DIR"' EXIT
 # shellcheck source=../relay/common.sh
 . "$REPO_DIR/relay/common.sh"
 
+# Every setup URL sink must use the shared validated output helper. Keep these
+# source checks beside its behavioral coverage so a new plain echo cannot bypass
+# the terminal and URL-safety guards.
+test "$(grep -cF '    print_phone_setup_url "$phone_url"' \
+    "$REPO_DIR/relay/common.sh" || true)" = 1
+for SETUP_URL_CALLER in setup-link.sh start.sh; do
+    test "$(grep -cF '    print_phone_setup_url "$DIRECT_URL"' \
+        "$REPO_DIR/relay/$SETUP_URL_CALLER" || true)" = 1
+    ! grep -Fq 'echo "  $DIRECT_URL"' "$REPO_DIR/relay/$SETUP_URL_CALLER"
+done
+unset SETUP_URL_CALLER
+
 id() {
     if [ "${1:-}" = "-u" ]; then
         printf '0\n'
@@ -213,7 +225,22 @@ cmp -s "$PHONE_SETUP_PLAIN_EXPECTED" "$PHONE_SETUP_ACTUAL"
 assert_phone_setup_rejected() {
     local name="$1"
     local url="$2"
-    local actual="$WORK_DIR/phone-setup-rejected-$name"
+    local link_actual="$WORK_DIR/phone-setup-link-rejected-$name"
+    local setup_actual="$WORK_DIR/phone-setup-rejected-$name"
+
+    if (
+        relay_binary() { printf '%s\n' "$PHONE_SETUP_NORMALIZER"; }
+        stdout_is_terminal() { return 0; }
+        unset NO_COLOR
+        TERM=xterm-256color print_phone_setup_url "$url"
+    ) > "$link_actual" 2>/dev/null; then
+        echo "setup URL helper accepted unsafe $name URL" >&2
+        exit 1
+    fi
+    if [ -s "$link_actual" ]; then
+        echo "setup URL helper printed unsafe $name URL" >&2
+        exit 1
+    fi
 
     if (
         relay_binary() { printf '%s\n' "$PHONE_SETUP_NORMALIZER"; }
@@ -221,11 +248,11 @@ assert_phone_setup_rejected() {
         stdout_is_terminal() { return 0; }
         unset NO_COLOR
         TERM=xterm-256color print_phone_setup "$url"
-    ) > "$actual" 2>/dev/null; then
+    ) > "$setup_actual" 2>/dev/null; then
         echo "phone setup accepted unsafe $name URL" >&2
         exit 1
     fi
-    if [ -s "$actual" ]; then
+    if [ -s "$setup_actual" ]; then
         echo "phone setup printed unsafe $name URL" >&2
         exit 1
     fi


### PR DESCRIPTION
## Summary

- emit the full private setup URL as one OSC 8 hyperlink on capable terminals
- keep redirected, `NO_COLOR`, and `TERM=dumb` output plain
- validate the URL before QR or terminal output to reject control bytes and unsafe origins
- add focused regression coverage for wrapping metadata, fallbacks, and unsafe inputs

## Why

Herdr preserves the inner pane's soft wrap, but its fullscreen frame presents the wrapped rows to the outer terminal as separate logical lines. WezTerm can infer a link only on the first row because the continuation row has no URL scheme. OSC 8 metadata keeps both rendered rows attached to the same complete URL.

## Validation

- focused phone setup output and security block: passed
- `bash -n relay/common.sh tests/test_common.sh`: passed
- final code review: approved
- final security review: approved

The full local `tests/test_common.sh` reaches unrelated macOS fixture failures in the existing physical `/tmp` and launchd service tests. The focused block passes independently, and CI can run the repository matrix.
