### PR TITLE
Add scrollback for alternate-screen panes

### DIFF
--- a/internal/app/server.go
+++ b/internal/app/server.go
@@ -46,6 +46,29 @@ import (
 	"github.com/0cv/herdr-mobile-relay/internal/workspace"
 )
 
+// A walk that actually walks scrolls the operator's pane for ~2s, returns far
+// more rows than one screen, and retires the seed. herdr declines instead while
+// anything holds the pane resized - a lease, or the measured ~85s after any
+// resize - and on opaque internal state that can last for hours; a decline
+// answers in ~1ms with exactly the visible screen and moves nothing. Declines
+// are therefore retried indefinitely on a spaced timer, costing nothing, and the
+// row count is what tells the two apart: only a response deeper than any screen
+// is a walk. The target depth matches the most herdr returns for one walk.
+const (
+	historySeedDeadline    = 20 * time.Second
+	historySeedRetry       = 15 * time.Second
+	historySeedResizeQuiet = 90 * time.Second
+	historySeedTargetDepth = 1000
+	historySeedDeclineRows = 100
+)
+
+// historySeedState tracks the walk of one pane generation.
+type historySeedState struct {
+	generation int64
+	lastTry    time.Time
+	done       bool
+}
+
 type copyResponseRunner func(
 	context.Context,
 	string,
@@ -112,10 +135,16 @@ type Server struct {
 	paneWatchMu sync.Mutex
 	paneWatches map[string]*paneWatch
 
-	historyCaptureMu  sync.Mutex
-	historyInflight   map[string]bool
-	historyLast       map[string]time.Time
-	historyActive     map[string]bool
+	historyCaptureMu sync.Mutex
+	historyInflight  map[string]bool
+	historyLast      map[string]time.Time
+	historyActive    map[string]bool
+	historySeeds     map[string]*historySeedState
+	// harvestTranscript overrides the pane walk in tests, which must never
+	// scroll a real pane.
+	harvestTranscript func(context.Context, string, int) (string, bool, error)
+	// paneLeaseActive overrides the lease/resize-quiet check in tests.
+	paneLeaseActive   func(string) bool
 	historyReconciled bool
 	transitionTasks   *lifecycleTasks
 	historyTasks      *lifecycleTasks
@@ -169,6 +198,7 @@ func New(cfg *config.Config, version, revision string, logger *slog.Logger) *Ser
 		historyInflight:     make(map[string]bool),
 		historyLast:         make(map[string]time.Time),
 		historyActive:       make(map[string]bool),
+		historySeeds:        make(map[string]*historySeedState),
 	}
 }
 
@@ -1347,13 +1377,24 @@ func (s *Server) captureHistoryLoop(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			for _, agent := range s.state.Snapshot() {
-				if !isClaudeLike(agent.Agent) || (agent.Status != "working" && agent.Status != "blocked") {
-					continue
-				}
-				s.scheduleHistoryCapture(ctx, agent.PaneID)
-			}
+			s.tickHistory(ctx)
 		}
+	}
+}
+
+// tickHistory routes every claude-like pane to the collector that can reach its
+// transcript: an active pane is captured invisibly from its live frames, an idle
+// one stops producing frames and is walked once instead.
+func (s *Server) tickHistory(ctx context.Context) {
+	for _, agent := range s.state.Snapshot() {
+		if !isClaudeLike(agent.Agent) {
+			continue
+		}
+		if agent.Status == "working" || agent.Status == "blocked" {
+			s.scheduleHistoryCapture(ctx, agent.PaneID)
+			continue
+		}
+		s.scheduleHistorySeed(agent.PaneID, historySeedTargetDepth)
 	}
 }
 
@@ -1402,6 +1443,129 @@ func (s *Server) scheduleHistoryCapture(ctx context.Context, paneID string) {
 	s.historyCaptureMu.Unlock()
 }
 
+func (s *Server) historySeedInFlight(paneID string) bool {
+	s.historyCaptureMu.Lock()
+	defer s.historyCaptureMu.Unlock()
+	seed := s.historySeeds[paneID]
+	return seed != nil && !seed.done && s.historyInflight[paneID]
+}
+
+// scheduleHistorySeed fills a pane's history from the transcript herdr can only
+// reach by walking the pane itself. Claude-like agents draw on the alternate
+// screen, which keeps no scrollback: every display read returns the visible rows
+// and nothing more, so a pane's history used to start at whichever screen the
+// relay first saw, while an agent with a real scrollback (omp) serves a thousand
+// rows on the first read. The walk scrolls the operator's pane for a couple of
+// seconds, so it happens once a client actually opens the pane, at most twice per
+// pane generation, and never while a capture is already reading.
+func (s *Server) scheduleHistorySeed(paneID string, limit int) {
+	harvest := s.harvestTranscript
+	if harvest == nil {
+		if s.dispatcher == nil {
+			return
+		}
+		harvest = s.dispatcher.HarvestPaneTranscript
+	}
+	if s.historyTasks == nil || limit < 1 {
+		return
+	}
+	// A pane whose agent is working or blocked is already captured in the
+	// background every few seconds, invisibly; herdr also declines to walk a
+	// pane that repaints under it. Walking is for the panes that loop ignores:
+	// the idle ones, whose transcript stops growing and would otherwise stay
+	// one screen deep forever.
+	agent, ok := s.state.Agent(paneID)
+	if !ok || !isClaudeLike(agent.Agent) {
+		return
+	}
+	if agent.Status == "working" || agent.Status == "blocked" {
+		return
+	}
+	// herdr declines the walk for as long as a lease holds the pane resized and
+	// for a measured ~85s after any resize. Those declines are not the pane's
+	// fault, so they must not spend its attempts: skip without burning until the
+	// pane has been at its own size for the full quiet window.
+	leased := s.paneLeaseActive
+	if leased == nil && s.paneSizeM != nil {
+		leased = func(id string) bool {
+			if _, ok := s.paneSizeM.ActiveColumns(id); ok {
+				return true
+			}
+			return s.paneSizeM.ResizedWithin(id, historySeedResizeQuiet)
+		}
+	}
+	if leased != nil && leased(paneID) {
+		return
+	}
+	generation := s.state.Generation(paneID)
+	s.historyCaptureMu.Lock()
+	seed := s.historySeeds[paneID]
+	if seed == nil || seed.generation != generation {
+		seed = &historySeedState{generation: generation}
+		s.historySeeds[paneID] = seed
+	}
+	depth := s.historyM.Depth(paneID)
+	switch {
+	case seed.done || s.historyInflight[paneID]:
+		s.historyCaptureMu.Unlock()
+		return
+	case depth >= limit:
+		// Deep enough already: an agent whose own scrollback herdr can read
+		// never needs a walk.
+		seed.done = true
+		s.historyCaptureMu.Unlock()
+		return
+	case !seed.lastTry.IsZero() && time.Since(seed.lastTry) < historySeedRetry:
+		s.historyCaptureMu.Unlock()
+		return
+	}
+	seed.lastTry = time.Now()
+	s.historyInflight[paneID] = true
+	s.historyCaptureMu.Unlock()
+
+	started := s.historyTasks.Start(func(taskCtx context.Context) {
+		defer func() {
+			s.historyCaptureMu.Lock()
+			delete(s.historyInflight, paneID)
+			s.historyCaptureMu.Unlock()
+		}()
+		readCtx, cancel := context.WithTimeout(taskCtx, historySeedDeadline)
+		defer cancel()
+		content, _, err := harvest(readCtx, paneID, history.MaxLines)
+		if err != nil {
+			s.logger.Warn("pane history seed failed", "pane_id", paneID, "error", err)
+			return
+		}
+		if s.state.Generation(paneID) != generation {
+			return
+		}
+		// A decline is exactly the visible screen; the watch frames carry that
+		// content already, and treating it as an answer would retire panes herdr
+		// merely was not ready to walk. Only a response deeper than any screen
+		// proves the pane was walked - and one walk fetches everything herdr
+		// will ever serve, so it retires the seed whether or not it held rows
+		// older than the watched history.
+		if strings.Count(content, "\n")+1 <= historySeedDeclineRows {
+			return
+		}
+		s.historyCaptureMu.Lock()
+		defer s.historyCaptureMu.Unlock()
+		if !s.historyActive[paneID] {
+			return
+		}
+		s.historyM.Seed(paneID, content, limit)
+		if current := s.historySeeds[paneID]; current != nil && current.generation == generation {
+			current.done = true
+		}
+	})
+	if started {
+		return
+	}
+	s.historyCaptureMu.Lock()
+	delete(s.historyInflight, paneID)
+	s.historyCaptureMu.Unlock()
+}
+
 func (s *Server) syncHistoryPanes(agents []*coordinator.AgentState) {
 	active := make(map[string]bool, len(agents))
 	for _, agent := range agents {
@@ -1422,6 +1586,7 @@ func (s *Server) syncHistoryPanes(agents []*coordinator.AgentState) {
 		}
 		delete(s.historyActive, paneID)
 		delete(s.historyLast, paneID)
+		delete(s.historySeeds, paneID)
 		s.historyM.Discard(paneID)
 	}
 	for paneID := range active {
@@ -1830,7 +1995,13 @@ func (s *Server) classifyPaneResponse(message, response map[string]any) map[stri
 		(!strings.Contains(agentLower, "claude") && !strings.Contains(agentLower, "qoder")) {
 		return response
 	}
-	if viewportOnly, _ := response["viewport_only"].(bool); viewportOnly {
+	// A leased pane is resized to the phone and its agent redraws the whole
+	// transcript at the new width, so only the frames inside that window must
+	// stay out of history. Holding a lease is the steady state while a phone
+	// views a pane, so skipping every leased frame left these agents - the only
+	// ones whose scrollback the relay has to accumulate itself - with no history
+	// at all, and nothing to scroll back through.
+	if settling, _ := response["resize_settling"].(bool); settling {
 		return response
 	}
 	historyLimit := messageInt(message["lines"], 30)
@@ -1838,6 +2009,11 @@ func (s *Server) classifyPaneResponse(message, response map[string]any) map[stri
 		historyLimit = 1
 	} else if historyLimit > history.MaxLines {
 		historyLimit = history.MaxLines
+	}
+	// Frames read while a harvest walks the pane show older screens; committing
+	// them would file scrolled-back rows as new output.
+	if s.historySeedInFlight(paneID) {
+		return response
 	}
 	herdrTruncated, _ := response["truncated"].(bool)
 	merged, historyTruncated := s.historyM.MergeLimited(paneID, content, historyLimit)

--- a/internal/app/server.go
+++ b/internal/app/server.go
@@ -50,23 +50,45 @@ import (
 // more rows than one screen, and retires the seed. herdr declines instead while
 // anything holds the pane resized - a lease, or the measured ~85s after any
 // resize - and on opaque internal state that can last for hours; a decline
-// answers in ~1ms with exactly the visible screen and moves nothing. Declines
-// are therefore retried indefinitely on a spaced timer, costing nothing, and the
-// row count is what tells the two apart: only a response deeper than any screen
-// is a walk. The target depth matches the most herdr returns for one walk.
+// answers in ~1ms with exactly the visible screen and moves nothing. The row
+// count is all that tells the two apart, and it cannot separate a decline from a
+// real walk of a pane whose whole transcript fits on one screen: only a response
+// deeper than any screen is certainly a walk. Short responses are therefore
+// retried on a spaced timer, but only a bounded number of times, so a genuinely
+// short pane stops being scrolled. The target depth matches the most herdr
+// returns for one walk.
 const (
 	historySeedDeadline    = 20 * time.Second
 	historySeedRetry       = 15 * time.Second
 	historySeedResizeQuiet = 90 * time.Second
 	historySeedTargetDepth = 1000
 	historySeedDeclineRows = 100
+	// historySeedMaxAttempts bounds the inconclusive answers one pane generation
+	// may produce. Declines cost nothing, but neither a walk that is short
+	// because the transcript is short nor a harvest that fails outright can be
+	// told apart from one, and retrying either forever scrolls the operator's
+	// pane - or burns an RPC and logs a warning - every 15s for as long as the
+	// pane lives. Eight attempts spend at most ~16s of visible movement when the
+	// pane answers fast, or eight historySeedDeadline reads when it does not
+	// answer at all; either way the seed is then retired, and only a new pane
+	// generation restores the budget. A merely slow pane is retired too, which
+	// is the price of bounding one the relay can never walk.
+	historySeedMaxAttempts = 8
 )
 
 // historySeedState tracks the walk of one pane generation.
 type historySeedState struct {
 	generation int64
 	lastTry    time.Time
-	done       bool
+	// walking is true only while this pane's harvest is running. The shared
+	// historyInflight map cannot stand in for it: an ordinary background
+	// capture sets that too, and a frame read during one of those is a plain
+	// frame that belongs in history.
+	walking bool
+	// attempts counts the inconclusive answers seen so far - short responses and
+	// failed harvests alike - bounded by historySeedMaxAttempts.
+	attempts int
+	done     bool
 }
 
 type copyResponseRunner func(
@@ -1443,11 +1465,28 @@ func (s *Server) scheduleHistoryCapture(ctx context.Context, paneID string) {
 	s.historyCaptureMu.Unlock()
 }
 
+// historySeedInFlight reports whether a harvest is currently scrolling the pane.
 func (s *Server) historySeedInFlight(paneID string) bool {
 	s.historyCaptureMu.Lock()
 	defer s.historyCaptureMu.Unlock()
 	seed := s.historySeeds[paneID]
-	return seed != nil && !seed.done && s.historyInflight[paneID]
+	return seed != nil && seed.walking
+}
+
+// spendSeedAttempt charges one attempt to a pane generation's seed and retires
+// the seed once the budget is gone. A stale generation is ignored: the pane it
+// described is gone, and its successor starts with a fresh budget.
+func (s *Server) spendSeedAttempt(paneID string, generation int64) {
+	s.historyCaptureMu.Lock()
+	defer s.historyCaptureMu.Unlock()
+	current := s.historySeeds[paneID]
+	if current == nil || current.generation != generation {
+		return
+	}
+	current.attempts++
+	if current.attempts >= historySeedMaxAttempts {
+		current.done = true
+	}
 }
 
 // scheduleHistorySeed fills a pane's history from the transcript herdr can only
@@ -1456,8 +1495,9 @@ func (s *Server) historySeedInFlight(paneID string) bool {
 // and nothing more, so a pane's history used to start at whichever screen the
 // relay first saw, while an agent with a real scrollback (omp) serves a thousand
 // rows on the first read. The walk scrolls the operator's pane for a couple of
-// seconds, so it happens once a client actually opens the pane, at most twice per
-// pane generation, and never while a capture is already reading.
+// seconds, so the background history tick walks every idle claude-like pane no
+// more often than historySeedRetry, never while a capture is already reading
+// that pane, and stops once a walk lands or the seed is retired.
 func (s *Server) scheduleHistorySeed(paneID string, limit int) {
 	harvest := s.harvestTranscript
 	if harvest == nil {
@@ -1520,6 +1560,7 @@ func (s *Server) scheduleHistorySeed(paneID string, limit int) {
 		return
 	}
 	seed.lastTry = time.Now()
+	seed.walking = true
 	s.historyInflight[paneID] = true
 	s.historyCaptureMu.Unlock()
 
@@ -1527,13 +1568,25 @@ func (s *Server) scheduleHistorySeed(paneID string, limit int) {
 		defer func() {
 			s.historyCaptureMu.Lock()
 			delete(s.historyInflight, paneID)
+			if current := s.historySeeds[paneID]; current != nil && current.generation == generation {
+				current.walking = false
+			}
 			s.historyCaptureMu.Unlock()
 		}()
 		readCtx, cancel := context.WithTimeout(taskCtx, historySeedDeadline)
 		defer cancel()
 		content, _, err := harvest(readCtx, paneID, history.MaxLines)
 		if err != nil {
+			// A failure is as inconclusive as a short response and just as
+			// repeatable: an older herdr with no walkable source, a missing CLI
+			// fallback, or a socket that answers but refuses this call all fail
+			// every time. Spending an attempt is what stops the 15s retry from
+			// re-reading such a pane for the life of the relay. A goroutine whose
+			// generation has already been replaced charges nothing:
+			// spendSeedAttempt matches on the seed record it started against, and
+			// the successor's record starts with a fresh budget.
 			s.logger.Warn("pane history seed failed", "pane_id", paneID, "error", err)
+			s.spendSeedAttempt(paneID, generation)
 			return
 		}
 		if s.state.Generation(paneID) != generation {
@@ -1545,7 +1598,15 @@ func (s *Server) scheduleHistorySeed(paneID string, limit int) {
 		// proves the pane was walked - and one walk fetches everything herdr
 		// will ever serve, so it retires the seed whether or not it held rows
 		// older than the watched history.
+		//
+		// A pane whose entire transcript fits on one screen answers a real walk
+		// with the same shape as a decline, and nothing in the response tells
+		// them apart: herdr's truncated flag only reports that it clipped the
+		// reply to the requested line count, so it is false for both, and the
+		// CLI fallback never sets it at all. Short responses are retried, but
+		// only historySeedMaxAttempts times, so such a pane stops being walked.
 		if strings.Count(content, "\n")+1 <= historySeedDeclineRows {
+			s.spendSeedAttempt(paneID, generation)
 			return
 		}
 		s.historyCaptureMu.Lock()
@@ -1553,7 +1614,7 @@ func (s *Server) scheduleHistorySeed(paneID string, limit int) {
 		if !s.historyActive[paneID] {
 			return
 		}
-		s.historyM.Seed(paneID, content, limit)
+		s.historyM.Seed(paneID, content)
 		if current := s.historySeeds[paneID]; current != nil && current.generation == generation {
 			current.done = true
 		}
@@ -1563,6 +1624,9 @@ func (s *Server) scheduleHistorySeed(paneID string, limit int) {
 	}
 	s.historyCaptureMu.Lock()
 	delete(s.historyInflight, paneID)
+	if current := s.historySeeds[paneID]; current != nil && current.generation == generation {
+		current.walking = false
+	}
 	s.historyCaptureMu.Unlock()
 }
 
@@ -2010,9 +2074,23 @@ func (s *Server) classifyPaneResponse(message, response map[string]any) map[stri
 	} else if historyLimit > history.MaxLines {
 		historyLimit = history.MaxLines
 	}
-	// Frames read while a harvest walks the pane show older screens; committing
-	// them would file scrolled-back rows as new output.
+	// A harvest scrolls the operator's real pane and snaps it back (see
+	// Dispatcher.HarvestPaneTranscript), so a frame read while one runs is a
+	// screen from the middle of that walk. Committing it would file scrolled-back
+	// rows as new output, and serving it would show the phone an old screen as
+	// the live pane. The stored rows are the honest answer until the walk ends;
+	// only a pane with nothing stored yet falls back to the frame itself.
 	if s.historySeedInFlight(paneID) {
+		// truncated describes the content actually returned, and that content is
+		// entirely the stored history: clipping it to historyLimit drops older
+		// rows, which the phone reports to the operator. herdr's flag describes
+		// the frame being discarded, so it must not survive the substitution -
+		// ORing it in would claim a complete transcript is clipped. The merge
+		// path below does OR, correctly, because it returns that frame.
+		if stored, storedTruncated := s.historyM.Content(paneID, historyLimit); stored != "" {
+			response["content"] = stored
+			response["truncated"] = storedTruncated
+		}
 		return response
 	}
 	herdrTruncated, _ := response["truncated"].(bool)

--- a/internal/app/server_test.go
+++ b/internal/app/server_test.go
@@ -280,7 +280,9 @@ func TestPaneWatchUpdateSendsResizeSettledDelta(t *testing.T) {
 	}
 }
 
-func TestPreparePaneResponsePreservesHistoryDuringResizeSession(t *testing.T) {
+// A width change makes the agent redraw its transcript, so those frames stay out
+// of history and the phone is shown the viewport alone.
+func TestPreparePaneResponsePreservesHistoryWhileResizeSettles(t *testing.T) {
 	s := testServerWithCacheDir(t.TempDir())
 	s.state.CommitInventory([]*coordinator.AgentState{{
 		PaneID: "pane-1", Agent: "claude", Status: "idle",
@@ -291,7 +293,7 @@ func TestPreparePaneResponsePreservesHistoryDuringResizeSession(t *testing.T) {
 	response := map[string]any{
 		"type": "pane_content", "pane_id": "pane-1",
 		"content": "current 1\ncurrent 2", "format": "ansi",
-		"truncated": false, "viewport_only": true,
+		"truncated": false, "viewport_only": true, "resize_settling": true,
 	}
 	s.preparePaneResponse(
 		map[string]any{"pane_id": "pane-1", "lines": 100, "terminal_columns": 59},
@@ -299,13 +301,302 @@ func TestPreparePaneResponsePreservesHistoryDuringResizeSession(t *testing.T) {
 	)
 
 	if response["content"] != "current 1\ncurrent 2" {
-		t.Fatalf("resized content = %q, want clean current viewport", response["content"])
+		t.Fatalf("settling content = %q, want clean current viewport", response["content"])
 	}
 	if response["truncated"] != false {
-		t.Fatalf("resized truncation = %#v, want false", response["truncated"])
+		t.Fatalf("settling truncation = %#v, want false", response["truncated"])
 	}
 	if content := s.historyM.Content("pane-1", 100); content != baseline {
-		t.Fatalf("history changed during resized read:\n%s", content)
+		t.Fatalf("history changed while the resize settled:\n%s", content)
+	}
+}
+
+// Holding a lease is the steady state while a phone views a pane. Skipping those
+// frames left an alternate-screen agent with no history at all, so the phone
+// could only ever scroll the visible screen.
+func TestPreparePaneResponseServesHistoryUnderStableLease(t *testing.T) {
+	s := testServerWithCacheDir(t.TempDir())
+	s.state.CommitInventory([]*coordinator.AgentState{{
+		PaneID: "pane-1", Agent: "claude", Status: "idle",
+	}}, s.state.RevisionCounter())
+	s.historyM.Merge("pane-1", "history 1\nhistory 2\nf1\nf2\nf3\nf4\nf5\nf6")
+
+	response := map[string]any{
+		"type": "pane_content", "pane_id": "pane-1",
+		"content": "current 1\ncurrent 2\nf1\nf2\nf3\nf4\nf5\nf6", "format": "ansi",
+		"truncated": false, "viewport_only": true,
+	}
+	s.preparePaneResponse(
+		map[string]any{"pane_id": "pane-1", "lines": 100, "terminal_columns": 59},
+		response,
+	)
+
+	content, _ := response["content"].(string)
+	for _, want := range []string{"history 1", "current 2"} {
+		if !strings.Contains(content, want) {
+			t.Fatalf("leased content %q lost %q", content, want)
+		}
+	}
+	if depth := s.historyM.Depth("pane-1"); depth != 4 {
+		t.Fatalf("leased frame history depth = %d, want the watched rows appended", depth)
+	}
+}
+
+const seedFooter = "\nf1\nf2\nf3\nf4\nf5\nf6"
+
+func testSeedServer(t *testing.T, harvest func(context.Context, string, int) (string, bool, error)) (*Server, *int) {
+	t.Helper()
+	s := testServerWithCacheDir(t.TempDir())
+	s.historyTasks = newLifecycleTasks(context.Background())
+	s.state.CommitInventory([]*coordinator.AgentState{{
+		PaneID: "pane-1", Agent: "claude", Status: "idle",
+	}}, s.state.RevisionCounter())
+	s.syncHistoryPanes(s.state.Snapshot())
+	s.paneLeaseActive = func(string) bool { return false }
+	calls := 0
+	s.harvestTranscript = func(ctx context.Context, paneID string, lines int) (string, bool, error) {
+		calls++
+		return harvest(ctx, paneID, lines)
+	}
+	return s, &calls
+}
+
+// runSeed drives one background tick's worth of seeding and waits it out.
+func runSeed(s *Server) {
+	s.scheduleHistorySeed("pane-1", historySeedTargetDepth)
+	s.historyTasks.Stop()
+	s.historyTasks = newLifecycleTasks(context.Background())
+	s.historyCaptureMu.Lock()
+	if seed := s.historySeeds["pane-1"]; seed != nil {
+		seed.lastTry = time.Time{}
+	}
+	s.historyCaptureMu.Unlock()
+}
+
+// walkedTranscript builds a harvest deep enough to be recognized as a real walk
+// rather than a declined one, which returns only the visible screen.
+func walkedTranscript(tail string) string {
+	rows := make([]string, 0, historySeedDeclineRows+20)
+	for index := range historySeedDeclineRows + 20 {
+		rows = append(rows, fmt.Sprintf("walked %03d", index))
+	}
+	return strings.Join(rows, "\n") + "\n" + tail
+}
+
+// An alternate-screen pane serves nothing but the visible rows, so its history
+// has to be walked out of the pane once; afterwards the phone can scroll back
+// through rows the relay never watched.
+func TestHistorySeedFillsAlternateScreenPane(t *testing.T) {
+	s, calls := testSeedServer(t, func(context.Context, string, int) (string, bool, error) {
+		return walkedTranscript("screen 1" + seedFooter), true, nil
+	})
+	s.historyM.Merge("pane-1", "screen 1"+seedFooter)
+
+	runSeed(s)
+
+	if *calls != 1 {
+		t.Fatalf("pane walked %d times, want exactly one", *calls)
+	}
+	content := s.historyM.Content("pane-1", 2000)
+	for _, want := range []string{"walked 000", "walked 119", "screen 1"} {
+		if !strings.Contains(content, want) {
+			t.Fatalf("seeded history %q lost %q", content, want)
+		}
+	}
+	if strings.Count(content, "screen 1") != 1 {
+		t.Fatalf("watched screen duplicated by the walk: %q", content)
+	}
+	runSeed(s)
+	if *calls != 1 {
+		t.Fatalf("pane walked again after a successful walk: %d", *calls)
+	}
+}
+
+// A pane whose history already reaches the walk's own ceiling has nothing a walk
+// could add; scrolling it would disturb the operator for nothing.
+func TestHistorySeedSkippedWhenHistoryAlreadyDeep(t *testing.T) {
+	s, calls := testSeedServer(t, func(context.Context, string, int) (string, bool, error) {
+		t.Error("deep pane was walked")
+		return "", false, nil
+	})
+
+	rows := make([]string, 0, historySeedTargetDepth+10)
+	for index := range historySeedTargetDepth + 10 {
+		rows = append(rows, fmt.Sprintf("scrollback %04d", index))
+	}
+	s.historyM.Merge("pane-1", strings.Join(rows, "\n")+seedFooter)
+	runSeed(s)
+
+	if *calls != 0 {
+		t.Fatalf("pane walked %d times despite a deep history", *calls)
+	}
+}
+
+// herdr declines by answering with exactly the visible screen, on internal state
+// that can last hours. A decline must neither retire the seed nor pollute
+// history; the walk lands whenever herdr finally agrees.
+func TestHistorySeedRetriesThroughDeclinesUntilAWalkLands(t *testing.T) {
+	declines := 5
+	s, calls := testSeedServer(t, func(context.Context, string, int) (string, bool, error) {
+		if declines > 0 {
+			declines--
+			return "screen 1" + seedFooter, false, nil
+		}
+		return walkedTranscript("screen 1" + seedFooter), true, nil
+	})
+	s.historyM.Merge("pane-1", "screen 1"+seedFooter)
+	before := s.historyM.Depth("pane-1")
+
+	for range 5 {
+		runSeed(s)
+	}
+	if *calls != 5 {
+		t.Fatalf("declined walks = %d, want one per tick", *calls)
+	}
+	if depth := s.historyM.Depth("pane-1"); depth != before {
+		t.Fatalf("a decline changed history depth %d -> %d", before, depth)
+	}
+
+	runSeed(s)
+	if !strings.Contains(s.historyM.Content("pane-1", 2000), "walked 000") {
+		t.Fatalf("walk after declines did not land")
+	}
+	runSeed(s)
+	if *calls != 6 {
+		t.Fatalf("walks = %d after success, want 6 (retired)", *calls)
+	}
+}
+
+// One walk fetches everything herdr will ever serve for the pane, so it retires
+// the seed even when every returned row was already watched - otherwise a pane
+// with a fully-captured transcript would be visibly walked on a loop.
+func TestHistorySeedRealWalkRetiresEvenWithoutNewRows(t *testing.T) {
+	transcript := walkedTranscript("screen 1" + seedFooter)
+	s, calls := testSeedServer(t, func(context.Context, string, int) (string, bool, error) {
+		return transcript, true, nil
+	})
+	s.historyM.Merge("pane-1", transcript)
+	before := s.historyM.Depth("pane-1")
+
+	runSeed(s)
+	runSeed(s)
+	runSeed(s)
+
+	if *calls != 1 {
+		t.Fatalf("fully-captured pane walked %d times, want 1", *calls)
+	}
+	if depth := s.historyM.Depth("pane-1"); depth != before {
+		t.Fatalf("re-seeding a captured transcript changed depth %d -> %d", before, depth)
+	}
+}
+
+// The walk scrolls the pane, so frames read during it show older screens. Filing
+// them as new output would interleave the transcript with its own past.
+func TestHistorySeedSuppressesMergeWhileWalking(t *testing.T) {
+	s, _ := testSeedServer(t, func(context.Context, string, int) (string, bool, error) {
+		return "", false, nil
+	})
+	s.historyM.Merge("pane-1", "watched 1"+seedFooter)
+	before := s.historyM.Depth("pane-1")
+
+	s.historyCaptureMu.Lock()
+	s.historySeeds["pane-1"] = &historySeedState{generation: s.state.Generation("pane-1")}
+	s.historyInflight["pane-1"] = true
+	s.historyCaptureMu.Unlock()
+
+	response := map[string]any{
+		"type": "pane_content", "pane_id": "pane-1",
+		"content": "scrolled back row" + seedFooter, "format": "ansi", "truncated": false,
+	}
+	s.preparePaneResponse(map[string]any{"pane_id": "pane-1", "lines": 100}, response)
+	if response["content"] != "scrolled back row"+seedFooter {
+		t.Fatalf("frame read during the walk was rewritten: %q", response["content"])
+	}
+	if depth := s.historyM.Depth("pane-1"); depth != before {
+		t.Fatalf("history depth %d -> %d during the walk", before, depth)
+	}
+}
+
+// Only agents drawing on the alternate screen need a walk; the others are read
+// straight through, history and all.
+func TestHistorySeedIgnoresAgentsWithScrollback(t *testing.T) {
+	s, calls := testSeedServer(t, func(context.Context, string, int) (string, bool, error) {
+		t.Error("pane of an agent with scrollback was walked")
+		return "", false, nil
+	})
+	s.state.CommitInventory([]*coordinator.AgentState{{
+		PaneID: "pane-1", Agent: "omp", Status: "idle",
+	}}, s.state.RevisionCounter())
+
+	runSeed(s)
+
+	if *calls != 0 {
+		t.Fatalf("omp pane walked %d times", *calls)
+	}
+}
+
+// A working pane is captured in the background already, and herdr declines to
+// walk a pane that repaints under it, so an attempt there would be spent for
+// nothing.
+func TestHistorySeedLeavesWorkingPanesToTheCaptureLoop(t *testing.T) {
+	s, calls := testSeedServer(t, func(context.Context, string, int) (string, bool, error) {
+		t.Error("working pane was walked")
+		return "", false, nil
+	})
+	s.state.CommitInventory([]*coordinator.AgentState{{
+		PaneID: "pane-1", Agent: "claude", Status: "working",
+	}}, s.state.RevisionCounter())
+
+	runSeed(s)
+
+	if *calls != 0 {
+		t.Fatalf("working pane walked %d times", *calls)
+	}
+}
+
+// herdr declines the walk for as long as a lease holds the pane resized and for
+// ~85s after; the seed does not even try then, and picks the pane up once it has
+// been at its own size for the quiet window.
+func TestHistorySeedWaitsOutLeases(t *testing.T) {
+	s, calls := testSeedServer(t, func(context.Context, string, int) (string, bool, error) {
+		return walkedTranscript("screen 1" + seedFooter), true, nil
+	})
+	leased := true
+	s.paneLeaseActive = func(string) bool { return leased }
+
+	for range 6 {
+		runSeed(s)
+	}
+	if *calls != 0 {
+		t.Fatalf("pane walked %d times while leased", *calls)
+	}
+
+	leased = false
+	runSeed(s)
+	if *calls != 1 {
+		t.Fatalf("pane walked %d times after the lease cleared, want 1", *calls)
+	}
+	if !strings.Contains(s.historyM.Content("pane-1", 2000), "walked 000") {
+		t.Fatalf("post-lease walk did not land")
+	}
+}
+
+// The background tick is what reaches idle panes; without it the walk would only
+// ever run for panes something else already touches.
+func TestHistoryTickWalksIdlePanes(t *testing.T) {
+	s, calls := testSeedServer(t, func(context.Context, string, int) (string, bool, error) {
+		return walkedTranscript("screen 1" + seedFooter), true, nil
+	})
+	s.historyM.Merge("pane-1", "screen 1"+seedFooter)
+
+	s.tickHistory(context.Background())
+	s.historyTasks.Stop()
+
+	if *calls != 1 {
+		t.Fatalf("idle pane walked %d times from the tick, want 1", *calls)
+	}
+	if !strings.Contains(s.historyM.Content("pane-1", 2000), "walked 000") {
+		t.Fatalf("tick walk did not land")
 	}
 }
 

--- a/internal/app/server_test.go
+++ b/internal/app/server_test.go
@@ -306,7 +306,7 @@ func TestPreparePaneResponsePreservesHistoryWhileResizeSettles(t *testing.T) {
 	if response["truncated"] != false {
 		t.Fatalf("settling truncation = %#v, want false", response["truncated"])
 	}
-	if content := s.historyM.Content("pane-1", 100); content != baseline {
+	if content, _ := s.historyM.Content("pane-1", 100); content != baseline {
 		t.Fatalf("history changed while the resize settled:\n%s", content)
 	}
 }
@@ -397,7 +397,7 @@ func TestHistorySeedFillsAlternateScreenPane(t *testing.T) {
 	if *calls != 1 {
 		t.Fatalf("pane walked %d times, want exactly one", *calls)
 	}
-	content := s.historyM.Content("pane-1", 2000)
+	content, _ := s.historyM.Content("pane-1", 2000)
 	for _, want := range []string{"walked 000", "walked 119", "screen 1"} {
 		if !strings.Contains(content, want) {
 			t.Fatalf("seeded history %q lost %q", content, want)
@@ -458,7 +458,7 @@ func TestHistorySeedRetriesThroughDeclinesUntilAWalkLands(t *testing.T) {
 	}
 
 	runSeed(s)
-	if !strings.Contains(s.historyM.Content("pane-1", 2000), "walked 000") {
+	if seeded, _ := s.historyM.Content("pane-1", 2000); !strings.Contains(seeded, "walked 000") {
 		t.Fatalf("walk after declines did not land")
 	}
 	runSeed(s)
@@ -490,17 +490,46 @@ func TestHistorySeedRealWalkRetiresEvenWithoutNewRows(t *testing.T) {
 	}
 }
 
-// The walk scrolls the pane, so frames read during it show older screens. Filing
-// them as new output would interleave the transcript with its own past.
+// A harvest that fails is as uninformative as a decline and far more repeatable:
+// an older herdr with no walkable source, a missing CLI fallback, or a socket
+// that refuses this one call fails identically every time. Without a bounded
+// budget the 15s retry re-read such a pane, and logged a warning, for as long as
+// the relay ran.
+func TestHistorySeedStopsWalkingAfterRepeatedFailures(t *testing.T) {
+	s, calls := testSeedServer(t, func(context.Context, string, int) (string, bool, error) {
+		return "", false, errors.New("herdr cannot walk this pane")
+	})
+	s.historyM.Merge("pane-1", "screen 1"+seedFooter)
+	before := s.historyM.Depth("pane-1")
+
+	for range historySeedMaxAttempts + 4 {
+		runSeed(s)
+	}
+
+	if *calls != historySeedMaxAttempts {
+		t.Fatalf("failed walks = %d, want the seed retired after %d", *calls, historySeedMaxAttempts)
+	}
+	if depth := s.historyM.Depth("pane-1"); depth != before {
+		t.Fatalf("a failed walk changed history depth %d -> %d", before, depth)
+	}
+}
+
+// The walk scrolls the operator's real pane and snaps it back, so frames read
+// during it show older screens. Filing them as new output would interleave the
+// transcript with its own past, and serving one would show the phone a screen
+// from the middle of the walk as though it were the live pane.
 func TestHistorySeedSuppressesMergeWhileWalking(t *testing.T) {
 	s, _ := testSeedServer(t, func(context.Context, string, int) (string, bool, error) {
 		return "", false, nil
 	})
 	s.historyM.Merge("pane-1", "watched 1"+seedFooter)
 	before := s.historyM.Depth("pane-1")
+	stored, _ := s.historyM.Content("pane-1", 100)
 
 	s.historyCaptureMu.Lock()
-	s.historySeeds["pane-1"] = &historySeedState{generation: s.state.Generation("pane-1")}
+	s.historySeeds["pane-1"] = &historySeedState{
+		generation: s.state.Generation("pane-1"), walking: true,
+	}
 	s.historyInflight["pane-1"] = true
 	s.historyCaptureMu.Unlock()
 
@@ -509,11 +538,160 @@ func TestHistorySeedSuppressesMergeWhileWalking(t *testing.T) {
 		"content": "scrolled back row" + seedFooter, "format": "ansi", "truncated": false,
 	}
 	s.preparePaneResponse(map[string]any{"pane_id": "pane-1", "lines": 100}, response)
-	if response["content"] != "scrolled back row"+seedFooter {
-		t.Fatalf("frame read during the walk was rewritten: %q", response["content"])
+	if response["content"] != stored {
+		t.Fatalf("mid-walk frame served as the live pane: %q, want the stored history %q",
+			response["content"], stored)
 	}
 	if depth := s.historyM.Depth("pane-1"); depth != before {
 		t.Fatalf("history depth %d -> %d during the walk", before, depth)
+	}
+}
+
+// The very first walk of a pane has nothing stored to serve instead, and a blank
+// terminal is worse than a scrolled one, so that frame is passed through.
+func TestHistorySeedServesTheFrameWhileWalkingAnEmptyHistory(t *testing.T) {
+	s, _ := testSeedServer(t, func(context.Context, string, int) (string, bool, error) {
+		return "", false, nil
+	})
+
+	s.historyCaptureMu.Lock()
+	s.historySeeds["pane-1"] = &historySeedState{
+		generation: s.state.Generation("pane-1"), walking: true,
+	}
+	s.historyInflight["pane-1"] = true
+	s.historyCaptureMu.Unlock()
+
+	response := map[string]any{
+		"type": "pane_content", "pane_id": "pane-1",
+		"content": "first screen" + seedFooter, "format": "ansi", "truncated": false,
+	}
+	s.preparePaneResponse(map[string]any{"pane_id": "pane-1", "lines": 100}, response)
+	if response["content"] != "first screen"+seedFooter {
+		t.Fatalf("frame blanked while walking an empty history: %q", response["content"])
+	}
+	// Falling through to the merge would return this same frame, so the returned
+	// content alone cannot tell the fallback from the bug the guard exists to
+	// prevent: the mid-walk screen must not be committed either.
+	if depth := s.historyM.Depth("pane-1"); depth != 0 {
+		t.Fatalf("mid-walk frame committed to history: depth = %d, want 0", depth)
+	}
+}
+
+// Clipping the substituted history to the requested lines drops older rows just
+// as a merge would, and the phone renders that flag as "Older terminal history
+// is not shown". The flag has to describe the rows actually served: reporting
+// the discarded frame's truncation got it wrong in both directions - the notice
+// vanished while a clipped transcript was served, and appeared while a complete
+// one was.
+func TestHistorySeedReportsTruncationOfSubstitutedHistory(t *testing.T) {
+	s, _ := testSeedServer(t, func(context.Context, string, int) (string, bool, error) {
+		return "", false, nil
+	})
+	rows := make([]string, 0, 40)
+	for index := range 40 {
+		rows = append(rows, fmt.Sprintf("stored %02d", index))
+	}
+	s.historyM.Merge("pane-1", strings.Join(rows, "\n")+seedFooter)
+
+	s.historyCaptureMu.Lock()
+	s.historySeeds["pane-1"] = &historySeedState{
+		generation: s.state.Generation("pane-1"), walking: true,
+	}
+	s.historyInflight["pane-1"] = true
+	s.historyCaptureMu.Unlock()
+
+	response := map[string]any{
+		"type": "pane_content", "pane_id": "pane-1",
+		"content": "scrolled back row" + seedFooter, "format": "ansi", "truncated": false,
+	}
+	s.preparePaneResponse(map[string]any{"pane_id": "pane-1", "lines": 10}, response)
+
+	if response["truncated"] != true {
+		t.Fatalf("mid-walk truncation = %#v, want true: the served history is clipped to 10 rows",
+			response["truncated"])
+	}
+	served, _ := response["content"].(string)
+	if strings.Contains(served, "stored 00") {
+		t.Fatalf("served content was not clipped to the requested lines: %q", served)
+	}
+	if !strings.Contains(served, "stored 39") {
+		t.Fatalf("served content lost the newest stored rows: %q", served)
+	}
+
+	// The converse: the discarded frame's own flag must not leak into a response
+	// whose stored history fits the request whole.
+	whole := map[string]any{
+		"type": "pane_content", "pane_id": "pane-1",
+		"content": "scrolled back row" + seedFooter, "format": "ansi", "truncated": true,
+	}
+	s.preparePaneResponse(map[string]any{"pane_id": "pane-1", "lines": 100}, whole)
+	if whole["truncated"] != false {
+		t.Fatalf("complete history reported as clipped: %#v, want false", whole["truncated"])
+	}
+}
+
+// A pane keeps its seed record after a declined walk, and the ordinary capture
+// loop marks the same pane in flight every few seconds. Reading the shared
+// in-flight map as "a walk is running" therefore dropped watch frames from
+// history for seconds at a time, on a pane nothing was scrolling - and for an
+// alternate-screen agent the relay is the only thing accumulating that
+// scrollback, so those rows were lost for good.
+func TestHistoryMergesFrameWhileOrdinaryCaptureRuns(t *testing.T) {
+	s, _ := testSeedServer(t, func(context.Context, string, int) (string, bool, error) {
+		return "", false, nil
+	})
+	s.historyM.Merge("pane-1", "watched 1\nwatched 2"+seedFooter)
+	before := s.historyM.Depth("pane-1")
+
+	s.historyCaptureMu.Lock()
+	// A seed left over from a declined walk: still pending, but not walking.
+	s.historySeeds["pane-1"] = &historySeedState{generation: s.state.Generation("pane-1")}
+	// The background capture loop holds the pane for the length of its read.
+	s.historyInflight["pane-1"] = true
+	s.historyCaptureMu.Unlock()
+
+	response := map[string]any{
+		"type": "pane_content", "pane_id": "pane-1",
+		"content": "current 1\ncurrent 2" + seedFooter, "format": "ansi", "truncated": false,
+	}
+	s.preparePaneResponse(map[string]any{"pane_id": "pane-1", "lines": 100}, response)
+
+	content, _ := response["content"].(string)
+	for _, want := range []string{"watched 1", "current 2"} {
+		if !strings.Contains(content, want) {
+			t.Fatalf("frame content %q lost %q", content, want)
+		}
+	}
+	if depth := s.historyM.Depth("pane-1"); depth != before+2 {
+		t.Fatalf("history depth %d -> %d, want the frame's rows appended", before, depth)
+	}
+}
+
+// A pane whose entire transcript fits on one screen answers a real walk with as
+// few rows as a decline does, and nothing in the response separates the two. Such
+// a pane can never reach the target depth either, so retrying it forever scrolled
+// the operator's pane every 15s for as long as the pane lived.
+func TestHistorySeedStopsWalkingAPaneThatOnlyEverAnswersShort(t *testing.T) {
+	s, calls := testSeedServer(t, func(context.Context, string, int) (string, bool, error) {
+		return "screen 1" + seedFooter, false, nil
+	})
+	s.historyM.Merge("pane-1", "screen 1"+seedFooter)
+
+	for range historySeedMaxAttempts + 4 {
+		runSeed(s)
+	}
+
+	if *calls != historySeedMaxAttempts {
+		t.Fatalf("short pane walked %d times, want at most %d", *calls, historySeedMaxAttempts)
+	}
+	s.historyCaptureMu.Lock()
+	seed := s.historySeeds["pane-1"]
+	s.historyCaptureMu.Unlock()
+	if seed == nil {
+		t.Fatal("seed record for a live pane disappeared")
+	}
+	if !seed.done {
+		t.Fatalf("seed still pending after %d short walks, want retired", seed.attempts)
 	}
 }
 
@@ -576,7 +754,7 @@ func TestHistorySeedWaitsOutLeases(t *testing.T) {
 	if *calls != 1 {
 		t.Fatalf("pane walked %d times after the lease cleared, want 1", *calls)
 	}
-	if !strings.Contains(s.historyM.Content("pane-1", 2000), "walked 000") {
+	if seeded, _ := s.historyM.Content("pane-1", 2000); !strings.Contains(seeded, "walked 000") {
 		t.Fatalf("post-lease walk did not land")
 	}
 }
@@ -595,7 +773,7 @@ func TestHistoryTickWalksIdlePanes(t *testing.T) {
 	if *calls != 1 {
 		t.Fatalf("idle pane walked %d times from the tick, want 1", *calls)
 	}
-	if !strings.Contains(s.historyM.Content("pane-1", 2000), "walked 000") {
+	if seeded, _ := s.historyM.Content("pane-1", 2000); !strings.Contains(seeded, "walked 000") {
 		t.Fatalf("tick walk did not land")
 	}
 }
@@ -1398,7 +1576,11 @@ func TestBackgroundClaudeHistoryCaptureDoesNotRequirePhoneRead(t *testing.T) {
 
 	s.scheduleHistoryCapture(context.Background(), "pane-1")
 	deadline := time.Now().Add(2 * time.Second)
-	for !strings.Contains(s.historyM.Content("pane-1", 100), "second output") {
+	captured := func() string {
+		content, _ := s.historyM.Content("pane-1", 100)
+		return content
+	}
+	for !strings.Contains(captured(), "second output") {
 		if time.Now().After(deadline) {
 			t.Fatal("background capture did not persist Claude pane output")
 		}

--- a/internal/coordinator/dispatch.go
+++ b/internal/coordinator/dispatch.go
@@ -1052,6 +1052,21 @@ func (d *Dispatcher) readPaneForDisplay(
 	return d.herdr.ReadPaneRecent(ctx, paneID, lines, format)
 }
 
+// HarvestPaneTranscript returns the pane's transcript from beyond its visible
+// screen. Herdr serves this only in text format, and it pays for it by scrolling
+// the operator's real pane up and snapping it back — seconds of visible movement
+// per call, measured at ~2s for a 1000-line read. No polling path may reach it
+// (see TestTextFormatDisplayReadNeverHarvestsScrollback); it exists to seed the
+// history of an alternate-screen pane, whose display reads can never return more
+// than the screen because it keeps no scrollback of its own.
+func (d *Dispatcher) HarvestPaneTranscript(ctx context.Context, paneID string, lines int) (string, bool, error) {
+	read, err := d.herdr.ReadPane(ctx, paneID, lines, "text")
+	if err != nil {
+		return "", false, err
+	}
+	return string(read.Content), read.Truncated, nil
+}
+
 func (d *Dispatcher) HandleReadPane(ctx context.Context, message map[string]any) map[string]any {
 	paneID := stringValue(message, "pane_id")
 	if paneID == "" {

--- a/internal/coordinator/pane_read_test.go
+++ b/internal/coordinator/pane_read_test.go
@@ -161,3 +161,39 @@ func TestTextFormatDisplayReadNeverHarvestsScrollback(t *testing.T) {
 		t.Fatalf("text-format reads did not all use the visible screen: %s", invocations)
 	}
 }
+
+// The seeding path is the one caller allowed to harvest, and it must ask for the
+// logical transcript in text format: an ansi read of an alternate-screen pane
+// never returns more than the visible screen.
+func TestHarvestPaneTranscriptReadsUnwrappedText(t *testing.T) {
+	dir := t.TempDir()
+	record := filepath.Join(dir, "invocations.log")
+	bin := writeScript(t, dir, "herdr", "#!/bin/sh\n"+
+		"printf '%s\\n' \"$*\" >> \""+record+"\"\n"+
+		"echo harvested\n")
+	state := NewState(testLogger())
+	state.CommitInventory([]*AgentState{
+		{PaneID: "pane-claude", Agent: "claude", Status: "idle"},
+	}, state.RevisionCounter())
+	dispatcher := NewDispatcher(
+		herdr.NewClient(bin, filepath.Join(dir, "missing.sock")),
+		state,
+		nil,
+		testLogger(),
+	)
+
+	content, _, err := dispatcher.HarvestPaneTranscript(context.Background(), "pane-claude", 1000)
+	if err != nil {
+		t.Fatalf("harvest failed: %v", err)
+	}
+	if strings.TrimSpace(content) != "harvested" {
+		t.Fatalf("harvested content = %q", content)
+	}
+	invocations, err := os.ReadFile(record)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(invocations), "--lines 1000 --source recent-unwrapped --format text") {
+		t.Fatalf("harvest did not request the logical transcript: %s", invocations)
+	}
+}

--- a/internal/history/history.go
+++ b/internal/history/history.go
@@ -106,6 +106,66 @@ func (m *Manager) Content(paneID string, limit int) string {
 	return content
 }
 
+// Depth reports how many history rows are stored for a pane, excluding the
+// footer. Callers use it to decide whether a pane still needs a seed.
+func (m *Manager) Depth(paneID string) int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.loadState(paneID).History)
+}
+
+// Seed installs a transcript harvested from the pane's own scrollback beneath
+// the rows the relay watched. An alternate-screen agent keeps no scrollback a
+// display read can reach, so without a seed a pane's history begins at whatever
+// screen the relay happened to see first. The harvest ends at the pane's current
+// screen, so its tail is the same content the stored history already holds:
+// the overlap is dropped rather than duplicated, and the stored rows win because
+// they carry the ANSI styling the harvested text lost.
+func (m *Manager) Seed(paneID string, rawContent string, limit int) (string, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	state := m.loadState(paneID)
+	body, footer := splitSnapshot(rawContent)
+	if len(body) == 0 {
+		return joinContent(state, limit)
+	}
+	if len(state.History) == 0 {
+		state.History = body
+		if len(state.Footer) == 0 {
+			state.Footer = footer
+		}
+	} else if older := seedPrefix(body, state.History); len(older) > 0 {
+		state.History = append(older, state.History...)
+	}
+	if len(state.History) > MaxLines {
+		state.History = state.History[len(state.History)-MaxLines:]
+	}
+
+	m.maybeSave(paneID, state)
+	return joinContent(state, limit)
+}
+
+// seedPrefix returns the seed rows that precede the stored history. The exact
+// tail-to-head overlap is tried first; a partial match anywhere is the fallback,
+// because a pane read at one width and harvested at another reflows its own
+// output and only some rows survive verbatim.
+func seedPrefix(seed, history []string) []string {
+	seedNorm := normalizeLines(seed)
+	histNorm := normalizeLines(history)
+	if overlap := tailOverlap(seedNorm, histNorm); overlap > 0 {
+		return seed[:len(seed)-overlap]
+	}
+	match := sequenceMatch(seedNorm, histNorm)
+	if match.Size < 2 {
+		return seed
+	}
+	if match.A <= match.B {
+		return nil
+	}
+	return seed[:match.A-match.B]
+}
+
 func (m *Manager) Discard(paneID string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/internal/history/history.go
+++ b/internal/history/history.go
@@ -97,13 +97,15 @@ func (m *Manager) merge(paneID string, rawContent string, limit int) (string, bo
 	return joinContent(state, limit)
 }
 
-func (m *Manager) Content(paneID string, limit int) string {
+// Content returns the pane's stored history clipped to its newest limit lines,
+// and whether clipping dropped anything - the same contract as MergeLimited,
+// because a caller that serves this to a client has to tell it the transcript
+// continues above what it received.
+func (m *Manager) Content(paneID string, limit int) (string, bool) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	state := m.loadState(paneID)
-	content, _ := joinContent(state, limit)
-	return content
+	return joinContent(m.loadState(paneID), limit)
 }
 
 // Depth reports how many history rows are stored for a pane, excluding the
@@ -121,14 +123,19 @@ func (m *Manager) Depth(paneID string) int {
 // screen, so its tail is the same content the stored history already holds:
 // the overlap is dropped rather than duplicated, and the stored rows win because
 // they carry the ANSI styling the harvested text lost.
-func (m *Manager) Seed(paneID string, rawContent string, limit int) (string, bool) {
+//
+// Seeding is a store, not a read: it returns nothing because joining up to
+// MaxLines rows into one string costs an allocation and a copy of the whole
+// transcript, and a seed happens once per pane rather than per frame. Callers
+// that want the result read it back with Content.
+func (m *Manager) Seed(paneID string, rawContent string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
 	state := m.loadState(paneID)
 	body, footer := splitSnapshot(rawContent)
 	if len(body) == 0 {
-		return joinContent(state, limit)
+		return
 	}
 	if len(state.History) == 0 {
 		state.History = body
@@ -143,7 +150,6 @@ func (m *Manager) Seed(paneID string, rawContent string, limit int) (string, boo
 	}
 
 	m.maybeSave(paneID, state)
-	return joinContent(state, limit)
 }
 
 // seedPrefix returns the seed rows that precede the stored history. The exact

--- a/internal/history/history_test.go
+++ b/internal/history/history_test.go
@@ -220,3 +220,105 @@ func TestReconcileRemovesHistoryLeftByEarlierProcess(t *testing.T) {
 		t.Fatalf("active pane history was removed: %v", err)
 	}
 }
+
+// A pane the relay never watched from the start has no rows to align against,
+// so the harvested transcript becomes the whole history.
+func TestSeedFillsEmptyHistory(t *testing.T) {
+	m := NewManager(t.TempDir())
+	footers := "\nf1\nf2\nf3\nf4\nf5\nf6"
+
+	content, _ := m.Seed("pane-1", "old 1\nold 2\nold 3"+footers, 100)
+	if !strings.Contains(content, "old 1") || !strings.Contains(content, "f6") {
+		t.Fatalf("seeded content = %q, want the harvested rows and footer", content)
+	}
+	if depth := m.Depth("pane-1"); depth != 3 {
+		t.Fatalf("seeded depth = %d, want the three harvested body rows", depth)
+	}
+}
+
+// The harvest ends at the screen the relay is already watching, so the rows it
+// shares with the stored history must not appear twice.
+func TestSeedPrependsOnlyOlderRows(t *testing.T) {
+	m := NewManager(t.TempDir())
+	footers := "\nf1\nf2\nf3\nf4\nf5\nf6"
+	m.Merge("pane-1", "watched 1\nwatched 2\nwatched 3"+footers)
+
+	content, _ := m.Seed("pane-1", "old 1\nold 2\nwatched 1\nwatched 2\nwatched 3"+footers, 100)
+	if strings.Count(content, "watched 1") != 1 {
+		t.Fatalf("overlapping row duplicated: %q", content)
+	}
+	rows := strings.Split(content, "\n")
+	if rows[0] != "old 1" || rows[2] != "watched 1" {
+		t.Fatalf("seeded order = %#v, want harvested rows beneath watched rows", rows[:3])
+	}
+	if depth := m.Depth("pane-1"); depth != 5 {
+		t.Fatalf("seeded depth = %d, want 2 harvested + 3 watched rows", depth)
+	}
+}
+
+// Styled rows the relay watched outrank the harvest, which loses ANSI.
+func TestSeedKeepsWatchedStyling(t *testing.T) {
+	m := NewManager(t.TempDir())
+	footers := "\nf1\nf2\nf3\nf4\nf5\nf6"
+	m.Merge("pane-1", "\x1b[42mApprove\x1b[0m\nwatched tail"+footers)
+
+	content, _ := m.Seed("pane-1", "old 1\nApprove\nwatched tail"+footers, 100)
+	if !strings.Contains(content, "\x1b[42mApprove") {
+		t.Fatalf("seed replaced the styled row: %q", content)
+	}
+	if strings.Count(content, "Approve") != 1 {
+		t.Fatalf("styled row duplicated by its plain harvest: %q", content)
+	}
+}
+
+// A pane read at one width and harvested at another reflows its own output, so
+// only part of the overlap survives verbatim; the partial match still places the
+// seam.
+func TestSeedAlignsOnPartialMatch(t *testing.T) {
+	m := NewManager(t.TempDir())
+	footers := "\nf1\nf2\nf3\nf4\nf5\nf6"
+	m.Merge("pane-1", "shared a\nshared b\nreflowed at phone width"+footers)
+
+	content, _ := m.Seed("pane-1", "old 1\nold 2\nshared a\nshared b\nreflowed at desktop width"+footers, 100)
+	if strings.Count(content, "shared a") != 1 {
+		t.Fatalf("matched row duplicated: %q", content)
+	}
+	if !strings.Contains(content, "old 1") {
+		t.Fatalf("older rows dropped: %q", content)
+	}
+	if strings.Contains(content, "reflowed at desktop width") {
+		t.Fatalf("seed kept its own copy of a row the relay already watched: %q", content)
+	}
+}
+
+// Nothing older than the stored history means nothing to prepend.
+func TestSeedIsIdempotent(t *testing.T) {
+	m := NewManager(t.TempDir())
+	footers := "\nf1\nf2\nf3\nf4\nf5\nf6"
+	seed := "old 1\nold 2\nold 3" + footers
+	m.Seed("pane-1", seed, 100)
+	first := m.Depth("pane-1")
+
+	m.Seed("pane-1", seed, 100)
+	if second := m.Depth("pane-1"); second != first {
+		t.Fatalf("second seed changed depth %d -> %d", first, second)
+	}
+}
+
+// Live frames keep appending after a seed, and the seeded rows stay beneath them.
+func TestSeedThenMergeKeepsBothEnds(t *testing.T) {
+	m := NewManager(t.TempDir())
+	footers := "\nf1\nf2\nf3\nf4\nf5\nf6"
+	m.Merge("pane-1", "watched 1\nwatched 2"+footers)
+	m.Seed("pane-1", "old 1\nwatched 1\nwatched 2"+footers, 100)
+
+	content, _ := m.MergeLimited("pane-1", "watched 2\nwatched 3"+footers, 100)
+	for _, want := range []string{"old 1", "watched 1", "watched 3"} {
+		if !strings.Contains(content, want) {
+			t.Fatalf("merged content lost %q: %q", want, content)
+		}
+	}
+	if strings.Count(content, "watched 2") != 1 {
+		t.Fatalf("row duplicated across seed and merge: %q", content)
+	}
+}

--- a/internal/history/history_test.go
+++ b/internal/history/history_test.go
@@ -227,7 +227,8 @@ func TestSeedFillsEmptyHistory(t *testing.T) {
 	m := NewManager(t.TempDir())
 	footers := "\nf1\nf2\nf3\nf4\nf5\nf6"
 
-	content, _ := m.Seed("pane-1", "old 1\nold 2\nold 3"+footers, 100)
+	m.Seed("pane-1", "old 1\nold 2\nold 3"+footers)
+	content, _ := m.Content("pane-1", 100)
 	if !strings.Contains(content, "old 1") || !strings.Contains(content, "f6") {
 		t.Fatalf("seeded content = %q, want the harvested rows and footer", content)
 	}
@@ -243,7 +244,8 @@ func TestSeedPrependsOnlyOlderRows(t *testing.T) {
 	footers := "\nf1\nf2\nf3\nf4\nf5\nf6"
 	m.Merge("pane-1", "watched 1\nwatched 2\nwatched 3"+footers)
 
-	content, _ := m.Seed("pane-1", "old 1\nold 2\nwatched 1\nwatched 2\nwatched 3"+footers, 100)
+	m.Seed("pane-1", "old 1\nold 2\nwatched 1\nwatched 2\nwatched 3"+footers)
+	content, _ := m.Content("pane-1", 100)
 	if strings.Count(content, "watched 1") != 1 {
 		t.Fatalf("overlapping row duplicated: %q", content)
 	}
@@ -262,7 +264,8 @@ func TestSeedKeepsWatchedStyling(t *testing.T) {
 	footers := "\nf1\nf2\nf3\nf4\nf5\nf6"
 	m.Merge("pane-1", "\x1b[42mApprove\x1b[0m\nwatched tail"+footers)
 
-	content, _ := m.Seed("pane-1", "old 1\nApprove\nwatched tail"+footers, 100)
+	m.Seed("pane-1", "old 1\nApprove\nwatched tail"+footers)
+	content, _ := m.Content("pane-1", 100)
 	if !strings.Contains(content, "\x1b[42mApprove") {
 		t.Fatalf("seed replaced the styled row: %q", content)
 	}
@@ -279,7 +282,8 @@ func TestSeedAlignsOnPartialMatch(t *testing.T) {
 	footers := "\nf1\nf2\nf3\nf4\nf5\nf6"
 	m.Merge("pane-1", "shared a\nshared b\nreflowed at phone width"+footers)
 
-	content, _ := m.Seed("pane-1", "old 1\nold 2\nshared a\nshared b\nreflowed at desktop width"+footers, 100)
+	m.Seed("pane-1", "old 1\nold 2\nshared a\nshared b\nreflowed at desktop width"+footers)
+	content, _ := m.Content("pane-1", 100)
 	if strings.Count(content, "shared a") != 1 {
 		t.Fatalf("matched row duplicated: %q", content)
 	}
@@ -296,10 +300,10 @@ func TestSeedIsIdempotent(t *testing.T) {
 	m := NewManager(t.TempDir())
 	footers := "\nf1\nf2\nf3\nf4\nf5\nf6"
 	seed := "old 1\nold 2\nold 3" + footers
-	m.Seed("pane-1", seed, 100)
+	m.Seed("pane-1", seed)
 	first := m.Depth("pane-1")
 
-	m.Seed("pane-1", seed, 100)
+	m.Seed("pane-1", seed)
 	if second := m.Depth("pane-1"); second != first {
 		t.Fatalf("second seed changed depth %d -> %d", first, second)
 	}
@@ -310,7 +314,7 @@ func TestSeedThenMergeKeepsBothEnds(t *testing.T) {
 	m := NewManager(t.TempDir())
 	footers := "\nf1\nf2\nf3\nf4\nf5\nf6"
 	m.Merge("pane-1", "watched 1\nwatched 2"+footers)
-	m.Seed("pane-1", "old 1\nwatched 1\nwatched 2"+footers, 100)
+	m.Seed("pane-1", "old 1\nwatched 1\nwatched 2"+footers)
 
 	content, _ := m.MergeLimited("pane-1", "watched 2\nwatched 3"+footers, 100)
 	for _, want := range []string{"old 1", "watched 1", "watched 3"} {


### PR DESCRIPTION
Claude- and Qoder-style agents draw their interfaces on the terminal's alternate screen, which has no scrollback. A display read only contains the visible rows, so the phone could not scroll through output the relay had not already seen.

This retains alternate-screen snapshots in relay history and serves that history to pane reads. It seeds history by walking an alternate-screen pane once, with bounded, spaced retries for short or declined results. A failed or declined walk does not keep scrolling an operator's pane. Regular capture stays separate from walk state, and pane reads wait for an active walk instead of receiving an incomplete history response. Truncation now reflects the history served rather than an intermediate display read.

Checks run:

- `go build ./...`
- `go vet ./...`
- `test -z "$(gofmt -l $(find . -name '*.go' -not -path './frontend/node_modules/*'))"`
- `go test ./internal/app/... ./internal/history/... ./internal/coordinator/...` — app and history pass. Coordinator retains pre-existing macOS-only failures for `/private/var` canonicalization and the 104-character unix-socket path limit.
- `go test ./internal/coordinator/ 2>&1 | grep -c FAIL` on `upstream/main` and this branch — the failing test names are identical.
- `go test -race ./internal/app/... ./internal/history/...`