### PR TITLE
Discover slash commands for Kimi and OpenCode

### DIFF
--- a/internal/slashcmd/catalog.go
+++ b/internal/slashcmd/catalog.go
@@ -25,26 +25,33 @@ type Catalog struct {
 	Truncated bool      `json:"truncated"`
 }
 
-func CatalogFor(agent, cwd, home string) Catalog {
-	agentLower := strings.ToLower(strings.TrimSpace(agent))
-	var profileID string
-	switch agentLower {
+// profileIDForAgentName maps an agent name as herdr reports it onto a provider
+// profile ID. Both entrypoints resolve through this one table on purpose: while
+// they carried separate switches the two drifted, and a kimi or opencode pane
+// whose binary was missing from the relay's PATH fell through to the generic
+// path and got an empty palette - not even builtins.
+func profileIDForAgentName(agent string) string {
+	switch strings.ToLower(strings.TrimSpace(agent)) {
 	case "claude", "claude-code", "claude code":
-		profileID = "claude"
+		return "claude"
 	case "codex":
-		profileID = "codex"
+		return "codex"
 	case "qoder", "qodercli":
-		profileID = "qoder"
+		return "qoder"
 	case "pi", "pi-coding-agent":
-		profileID = "pi"
+		return "pi"
 	case "omp", "oh my pi", "oh-my-pi":
-		profileID = "omp"
+		return "omp"
 	case "kimi", "kimi code", "kimi-code", "kimi-cli":
-		profileID = "kimi"
+		return "kimi"
 	case "opencode", "open code", "open-code":
-		profileID = "opencode"
+		return "opencode"
 	}
-	return CatalogForProfile(profileID, agent, cwd, home, nil, "", "")
+	return ""
+}
+
+func CatalogFor(agent, cwd, home string) Catalog {
+	return CatalogForProfile(profileIDForAgentName(agent), agent, cwd, home, nil, "", "")
 }
 
 func CatalogForProfile(
@@ -65,19 +72,7 @@ func CatalogForProfile(
 
 	p := resolveProvider(profileID)
 	if p == nil && reportedAgent != "" {
-		agentLower := strings.ToLower(strings.TrimSpace(reportedAgent))
-		switch agentLower {
-		case "claude", "claude-code", "claude code":
-			p = resolveProvider("claude")
-		case "codex":
-			p = resolveProvider("codex")
-		case "qoder", "qodercli":
-			p = resolveProvider("qoder")
-		case "pi", "pi-coding-agent":
-			p = resolveProvider("pi")
-		case "omp", "oh my pi", "oh-my-pi":
-			p = resolveProvider("omp")
-		}
+		p = resolveProvider(profileIDForAgentName(reportedAgent))
 	}
 
 	if p != nil {

--- a/internal/slashcmd/frontmatter.go
+++ b/internal/slashcmd/frontmatter.go
@@ -14,7 +14,8 @@ func parseFrontmatterBytes(data []byte) (map[string]string, bool) {
 		return map[string]string{}, true
 	}
 	result := make(map[string]string)
-	for _, line := range lines[1:] {
+	for i := 1; i < len(lines); i++ {
+		line := lines[i]
 		if strings.TrimSpace(line) == "---" {
 			return result, true
 		}
@@ -24,12 +25,91 @@ func parseFrontmatterBytes(data []byte) (map[string]string, bool) {
 		}
 		key := strings.ToLower(matches[1])
 		value := matches[2]
-		if len(value) >= 2 && value[0] == value[len(value)-1] && (value[0] == '\'' || value[0] == '"') {
+		if folded, isBlock := blockScalarHeader(value); isBlock {
+			consumed := 0
+			value, consumed = foldBlockScalar(lines[i+1:], folded)
+			i += consumed
+		} else if len(value) >= 2 && value[0] == value[len(value)-1] && (value[0] == '\'' || value[0] == '"') {
 			value = value[1 : len(value)-1]
 		}
 		result[key] = value
 	}
 	return result, true
+}
+
+// blockScalarHeader reports whether value is a YAML block-scalar header such as
+// "|", "|-", ">-" or "|2+", and whether that header selects the folded style.
+// The indentation indicator is accepted but ignored: foldBlockScalar always
+// strips the block's own common indentation instead. Anything else - including a
+// plain scalar that merely starts with a pipe - is not a header.
+func blockScalarHeader(value string) (folded, ok bool) {
+	if value == "" {
+		return false, false
+	}
+	switch value[0] {
+	case '|':
+	case '>':
+		folded = true
+	default:
+		return false, false
+	}
+	for _, r := range value[1:] {
+		if r != '+' && r != '-' && (r < '1' || r > '9') {
+			return false, false
+		}
+	}
+	return folded, true
+}
+
+// foldBlockScalar joins the indented continuation lines of one block scalar and
+// returns the value plus the number of lines it consumed. The common indentation
+// is stripped, deeper relative indentation is preserved, literal blocks keep
+// their line breaks and folded blocks join lines with a space. The block ends at
+// the first non-empty line that is not indented past the key, at a "---" fence,
+// or at the end of the input; a block with no continuation lines yields "", so a
+// malformed one drops the skill rather than surfacing a bogus description.
+//
+// Chomping indicators are deliberately not honoured: every consumer runs the
+// value through compact, which collapses all whitespace runs anyway.
+func foldBlockScalar(rest []string, folded bool) (string, int) {
+	indent := -1
+	consumed := 0
+	var parts []string
+	for _, line := range rest {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "---" {
+			break
+		}
+		lineIndent := len(line) - len(strings.TrimLeft(line, " \t"))
+		if trimmed != "" && lineIndent == 0 {
+			break
+		}
+		consumed++
+		if trimmed == "" {
+			parts = append(parts, "")
+			continue
+		}
+		if indent < 0 || lineIndent < indent {
+			indent = lineIndent
+		}
+		parts = append(parts, line)
+	}
+	for len(parts) > 0 && parts[len(parts)-1] == "" {
+		parts = parts[:len(parts)-1]
+	}
+	if len(parts) == 0 {
+		return "", consumed
+	}
+	for i, part := range parts {
+		if part != "" {
+			parts[i] = part[indent:]
+		}
+	}
+	separator := "\n"
+	if folded {
+		separator = " "
+	}
+	return strings.Join(parts, separator), consumed
 }
 
 func readSkillMetadata(path string) (map[string]string, bool) {

--- a/internal/slashcmd/frontmatter.go
+++ b/internal/slashcmd/frontmatter.go
@@ -40,8 +40,9 @@ func parseFrontmatterBytes(data []byte) (map[string]string, bool) {
 // blockScalarHeader reports whether value is a YAML block-scalar header such as
 // "|", "|-", ">-" or "|2+", and whether that header selects the folded style.
 // The indentation indicator is accepted but ignored: foldBlockScalar always
-// strips the block's own common indentation instead. Anything else - including a
-// plain scalar that merely starts with a pipe - is not a header.
+// strips the block's own common indentation instead. A whitespace-delimited
+// trailing YAML comment is ignored. Anything else - including a plain scalar
+// that merely starts with a pipe - is not a header.
 func blockScalarHeader(value string) (folded, ok bool) {
 	if value == "" {
 		return false, false
@@ -53,7 +54,14 @@ func blockScalarHeader(value string) (folded, ok bool) {
 	default:
 		return false, false
 	}
-	for _, r := range value[1:] {
+	header := value
+	if comment := strings.IndexByte(value, '#'); comment > 0 {
+		previous := value[comment-1]
+		if previous == ' ' || previous == '\t' {
+			header = strings.TrimSpace(value[:comment])
+		}
+	}
+	for _, r := range header[1:] {
 		if r != '+' && r != '-' && (r < '1' || r > '9') {
 			return false, false
 		}
@@ -65,9 +73,9 @@ func blockScalarHeader(value string) (folded, ok bool) {
 // returns the value plus the number of lines it consumed. The common indentation
 // is stripped, deeper relative indentation is preserved, literal blocks keep
 // their line breaks and folded blocks join lines with a space. The block ends at
-// the first non-empty line that is not indented past the key, at a "---" fence,
-// or at the end of the input; a block with no continuation lines yields "", so a
-// malformed one drops the skill rather than surfacing a bogus description.
+// the first non-empty line that is not indented past the key or at the end of the
+// input; a block with no continuation lines yields "", so a malformed one drops
+// the skill rather than surfacing a bogus description.
 //
 // Chomping indicators are deliberately not honoured: every consumer runs the
 // value through compact, which collapses all whitespace runs anyway.
@@ -77,9 +85,6 @@ func foldBlockScalar(rest []string, folded bool) (string, int) {
 	var parts []string
 	for _, line := range rest {
 		trimmed := strings.TrimSpace(line)
-		if trimmed == "---" {
-			break
-		}
 		lineIndent := len(line) - len(strings.TrimLeft(line, " \t"))
 		if trimmed != "" && lineIndent == 0 {
 			break

--- a/internal/slashcmd/frontmatter_test.go
+++ b/internal/slashcmd/frontmatter_test.go
@@ -118,3 +118,180 @@ func TestReadSkillMetadataOversized(t *testing.T) {
 		t.Error("oversized file should return false")
 	}
 }
+
+// TestFrontmatterLiteralBlockScalar pins the real-world shape that used to yield
+// the literal description "|" in the palette.
+func TestFrontmatterLiteralBlockScalar(t *testing.T) {
+	data := []byte(`---
+name: archon
+description: |
+  Use when: User wants to run Archon workflows.
+  Triggers: "use archon to", "run archon".
+argument-hint: "[workflow] [message]"
+---
+Body text that must not leak into the description.
+`)
+	fm, ok := parseFrontmatterBytes(data)
+	if !ok {
+		t.Fatal("expected ok")
+	}
+	if fm["description"] == "|" {
+		t.Fatal(`description = "|": block scalar header was taken as the value`)
+	}
+	want := "Use when: User wants to run Archon workflows.\nTriggers: \"use archon to\", \"run archon\"."
+	if fm["description"] != want {
+		t.Errorf("description = %q, want %q", fm["description"], want)
+	}
+	wantCompact := `Use when: User wants to run Archon workflows. Triggers: "use archon to", "run archon".`
+	if got := compact(fm["description"], 240); got != wantCompact {
+		t.Errorf("compact(description) = %q, want %q", got, wantCompact)
+	}
+	if fm["name"] != "archon" {
+		t.Errorf("name = %q", fm["name"])
+	}
+	if fm["argument-hint"] != "[workflow] [message]" {
+		t.Errorf("argument-hint = %q: key after the block was not parsed", fm["argument-hint"])
+	}
+}
+
+func TestFrontmatterFoldedBlockScalar(t *testing.T) {
+	data := []byte(`---
+name: manage-run
+description: >-
+  Use when: User wants to INSPECT runs
+  driven through the archon CLI.
+---
+`)
+	fm, ok := parseFrontmatterBytes(data)
+	if !ok {
+		t.Fatal("expected ok")
+	}
+	if fm["description"] == ">-" {
+		t.Fatal(`description = ">-": block scalar header was taken as the value`)
+	}
+	want := "Use when: User wants to INSPECT runs driven through the archon CLI."
+	if fm["description"] != want {
+		t.Errorf("description = %q, want %q", fm["description"], want)
+	}
+}
+
+func TestFrontmatterBlockScalarHeaderVariants(t *testing.T) {
+	cases := []struct {
+		header string
+		want   string
+	}{
+		{"|", "alpha\nbeta"},
+		{"|-", "alpha\nbeta"},
+		{"|+", "alpha\nbeta"},
+		{"|2-", "alpha\nbeta"},
+		{">", "alpha beta"},
+		{">-", "alpha beta"},
+		{">+", "alpha beta"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.header, func(t *testing.T) {
+			data := []byte("---\ndescription: " + tc.header + "\n  alpha\n  beta\n---\n")
+			fm, ok := parseFrontmatterBytes(data)
+			if !ok {
+				t.Fatal("expected ok")
+			}
+			if fm["description"] != tc.want {
+				t.Errorf("description = %q, want %q", fm["description"], tc.want)
+			}
+		})
+	}
+}
+
+func TestFrontmatterBlockScalarKeepsRelativeIndent(t *testing.T) {
+	data := []byte("---\ndescription: |\n  line one\n    indented two\n  line three\n---\n")
+	fm, _ := parseFrontmatterBytes(data)
+	want := "line one\n  indented two\nline three"
+	if fm["description"] != want {
+		t.Errorf("description = %q, want %q", fm["description"], want)
+	}
+}
+
+func TestFrontmatterBlockScalarKeepsBlankLines(t *testing.T) {
+	data := []byte("---\ndescription: |\n  para one\n\n  para two\n\n---\n")
+	fm, _ := parseFrontmatterBytes(data)
+	want := "para one\n\npara two"
+	if fm["description"] != want {
+		t.Errorf("description = %q, want %q", fm["description"], want)
+	}
+}
+
+func TestFrontmatterBlockScalarEndsAtNextKey(t *testing.T) {
+	data := []byte("---\ndescription: |\n  first line\nname: after-block\n---\n")
+	fm, _ := parseFrontmatterBytes(data)
+	if fm["description"] != "first line" {
+		t.Errorf("description = %q", fm["description"])
+	}
+	if fm["name"] != "after-block" {
+		t.Errorf("name = %q: block swallowed the following key", fm["name"])
+	}
+}
+
+func TestFrontmatterBlockScalarEndsAtFence(t *testing.T) {
+	data := []byte("---\ndescription: |\n  first line\n---\nother: body line\n")
+	fm, _ := parseFrontmatterBytes(data)
+	if fm["description"] != "first line" {
+		t.Errorf("description = %q", fm["description"])
+	}
+	if _, exists := fm["other"]; exists {
+		t.Errorf("body key leaked into frontmatter: %v", fm)
+	}
+}
+
+// TestFrontmatterEmptyBlockScalarFailsOpen covers the malformed case: an empty
+// description drops the skill, which is safer than a one-character bogus one.
+func TestFrontmatterEmptyBlockScalarFailsOpen(t *testing.T) {
+	for _, data := range [][]byte{
+		[]byte("---\nname: broken\ndescription: |\n---\n"),
+		[]byte("---\nname: broken\ndescription: >-\n"),
+		[]byte("---\nname: broken\ndescription: |\nother: value\n---\n"),
+	} {
+		fm, ok := parseFrontmatterBytes(data)
+		if !ok {
+			t.Fatalf("expected ok for %q", data)
+		}
+		if fm["description"] != "" {
+			t.Errorf("description = %q for %q, want empty", fm["description"], data)
+		}
+	}
+}
+
+func TestFrontmatterPlainScalarStartingWithPipe(t *testing.T) {
+	data := []byte("---\ndescription: |not-a-header\nname: keeps-parsing\n---\n")
+	fm, _ := parseFrontmatterBytes(data)
+	if fm["description"] != "|not-a-header" {
+		t.Errorf("description = %q, want the plain scalar verbatim", fm["description"])
+	}
+	if fm["name"] != "keeps-parsing" {
+		t.Errorf("name = %q", fm["name"])
+	}
+}
+
+func TestReadSkillMetadataBlockScalarFromFile(t *testing.T) {
+	dir := t.TempDir()
+	path := dir + "/SKILL.md"
+	writeTestFile(t, path, "---\nname: deploy\ndescription: |\n  Ship the app\n  to production.\n---\nbody\n")
+
+	fm, ok := readSkillMetadata(path)
+	if !ok {
+		t.Fatal("expected ok")
+	}
+	if got := compact(fm["description"], 240); got != "Ship the app to production." {
+		t.Errorf("description = %q", got)
+	}
+}
+
+func TestReadSkillMetadataOversizedBlockScalar(t *testing.T) {
+	dir := t.TempDir()
+	path := dir + "/SKILL.md"
+	body := strings.Repeat("  filler line\n", maxMetadataSize/8)
+	writeTestFile(t, path, "---\nname: huge\ndescription: |\n"+body+"---\n")
+
+	if _, ok := readSkillMetadata(path); ok {
+		t.Error("oversized block scalar should still be rejected by maxMetadataSize")
+	}
+}

--- a/internal/slashcmd/frontmatter_test.go
+++ b/internal/slashcmd/frontmatter_test.go
@@ -184,6 +184,7 @@ func TestFrontmatterBlockScalarHeaderVariants(t *testing.T) {
 		{"|-", "alpha\nbeta"},
 		{"|+", "alpha\nbeta"},
 		{"|2-", "alpha\nbeta"},
+		{"|- # explanation", "alpha\nbeta"},
 		{">", "alpha beta"},
 		{">-", "alpha beta"},
 		{">+", "alpha beta"},
@@ -217,6 +218,29 @@ func TestFrontmatterBlockScalarKeepsBlankLines(t *testing.T) {
 	want := "para one\n\npara two"
 	if fm["description"] != want {
 		t.Errorf("description = %q, want %q", fm["description"], want)
+	}
+}
+
+func TestFrontmatterBlockScalarKeepsIndentedFence(t *testing.T) {
+	data := []byte(`---
+description: |
+  first paragraph
+  ---
+  second paragraph
+user-invocable: false
+argument-hint: <path>
+---
+`)
+	fm, _ := parseFrontmatterBytes(data)
+	want := "first paragraph\n---\nsecond paragraph"
+	if fm["description"] != want {
+		t.Errorf("description = %q, want %q", fm["description"], want)
+	}
+	if fm["user-invocable"] != "false" {
+		t.Errorf("user-invocable = %q: key after the block was not parsed", fm["user-invocable"])
+	}
+	if fm["argument-hint"] != "<path>" {
+		t.Errorf("argument-hint = %q: key after the block was not parsed", fm["argument-hint"])
 	}
 }
 

--- a/internal/slashcmd/provider_test.go
+++ b/internal/slashcmd/provider_test.go
@@ -69,6 +69,49 @@ func TestCatalogForExactDispatch(t *testing.T) {
 	}
 }
 
+// The relay passes an empty profileID whenever the agent's own binary is missing
+// from the service PATH, which is the norm under launchd's minimal environment. The
+// reportedAgent fallback is then the only thing that selects a provider, so it must
+// cover every name the exact-dispatch table above covers. Asserting through
+// CatalogFor alone cannot catch a gap here: that path supplies the profileID itself.
+// No environment isolation is needed - every assertion is on a builtin, and no
+// discovered directory can remove a builtin, only add alongside it.
+func TestCatalogForProfileFallbackCoversEveryAgentName(t *testing.T) {
+	tests := []struct {
+		agent       string
+		wantBuiltin string
+	}{
+		{"claude", "/clear"},
+		{"claude-code", "/clear"},
+		{"claude code", "/clear"},
+		{"codex", "/clear"},
+		{"qoder", "/clear"},
+		{"qodercli", "/clear"},
+		{"pi", "/model"},
+		{"pi-coding-agent", "/model"},
+		{"omp", "/model"},
+		{"oh my pi", "/model"},
+		{"oh-my-pi", "/model"},
+		{"kimi", "/model"},
+		{"kimi code", "/model"},
+		{"kimi-code", "/model"},
+		{"kimi-cli", "/model"},
+		{"opencode", "/models"},
+		{"open code", "/models"},
+		{"open-code", "/models"},
+	}
+	for _, tt := range tests {
+		catalog := CatalogForProfile("", tt.agent, "/tmp", "/nonexistent", nil, "", "")
+		if len(catalog.Commands) == 0 {
+			t.Errorf("CatalogForProfile(\"\", %q) returned an empty catalog", tt.agent)
+			continue
+		}
+		if !hasCommand(catalog, tt.wantBuiltin) {
+			t.Errorf("CatalogForProfile(\"\", %q) missing %q", tt.agent, tt.wantBuiltin)
+		}
+	}
+}
+
 func TestCatalogForNoSubstringMatch(t *testing.T) {
 	catalog := CatalogFor("not-claude-at-all", "/tmp", "/nonexistent")
 	if len(catalog.Commands) != 0 {

--- a/internal/slashcmd/walk_test.go
+++ b/internal/slashcmd/walk_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 func TestWalkFlat(t *testing.T) {
@@ -196,5 +197,33 @@ func TestFindGitRootWorktree(t *testing.T) {
 	got := findGitRoot(sub)
 	if got != root {
 		t.Errorf("findGitRoot = %q, want %q", got, root)
+	}
+}
+
+// walkDirBudget recurses, so a symlink pointing at an ancestor would be an
+// unbounded loop if the walk ever followed one. It does not - symlinks are
+// skipped outright, which is what makes the recursion safe without a
+// cross-level visited set. Anyone who later makes this walk follow symlinks
+// has to thread real-path de-duplication through the recursion to keep this
+// test passing; the budget alone will not save them, because recursing into a
+// directory does not spend it.
+func TestWalkSymlinkToAncestorTerminates(t *testing.T) {
+	dir := t.TempDir()
+	sub := filepath.Join(dir, "sub")
+	os.MkdirAll(sub, 0o755)
+	os.WriteFile(filepath.Join(sub, "real.md"), []byte("Real command"), 0o644)
+	if err := os.Symlink(dir, filepath.Join(sub, "loop")); err != nil {
+		t.Fatal(err)
+	}
+
+	done := make(chan []Command, 1)
+	go func() { done <- walkCommandDir(dir, "personal") }()
+	select {
+	case commands := <-done:
+		if len(commands) != 1 || commands[0].Command != "/sub:real" {
+			t.Errorf("expected only /sub:real, got %+v", commands)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("walk did not terminate on a symlink to an ancestor")
 	}
 }


### PR DESCRIPTION
A pane reporting Kimi or OpenCode could show an empty slash-command palette when no matching profile ID was available. Skills using YAML block-scalar frontmatter descriptions were skipped too.

The reported-agent fallback lacked the Kimi and OpenCode aliases even though direct dispatch had them. The frontmatter parser also read only the marker on a `description: |` or `description: >` line, not its indented content.

Direct and reported-agent dispatch now share an agent-name-to-profile table that includes those aliases. Skill discovery parses YAML literal and folded block-scalar descriptions. A regression test also covers a recursive command walk when a directory symlink points to an ancestor.

Verification:

- `go build ./...`
- `go vet ./...`
- `git ls-files -z -- '*.go' ':!vendor/**' | xargs -0 gofmt -l` (no output)
- `go test ./internal/slashcmd/...`
- `go test -race ./internal/slashcmd/...`