### PR TITLE
Ignore .omp checkout state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ relay/phone-app-origin.*
 .claude/
 .qoder/
 .codex/
+.omp/
 .ralph
 ralph.yml
 WATCHDOG.yml


### PR DESCRIPTION
The checkout already ignores the per-tool directories created by coding agents: `.claude/`, `.qoder/`, and `.codex/`. Oh My Pi writes `.omp/` for the same purpose, so this adds `.omp/` alongside them and keeps those files from being committed by accident.

A `.gitignore` rule does not untrack a path already in the index; an existing tracked `.omp/` file still needs `git rm --cached`. The change is one insertion in one file. `go build ./...` was unchanged because no code was touched.