### PR TITLE
Add Catppuccin Latte theme with a light terminal pane

### DIFF
--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -31,6 +31,8 @@
   --trust: #a178df;
   --terminal: #080808;
   --terminal-text: #e5e5e5;
+  --terminal-link: #80bfff;
+  --terminal-link-visited: #c8a2ff;
 }
 
 :root[data-theme='light'] {
@@ -111,6 +113,30 @@
   --trust: #c4a7e7;
   --terminal: #12101c;
   --terminal-text: #e0def4;
+}
+
+/* Catppuccin Latte: the one theme whose terminal pane is light as well, so a
+   desktop running the matching light scheme reads the same on the phone. */
+:root[data-theme='latte'] {
+  color-scheme: light;
+  --background: #eff1f5;
+  --foreground: #4c4f69;
+  --card: #e6e9ef;
+  --card-hover: #dce0e8;
+  --muted: #6c6f85;
+  --border: #ccd0da;
+  --input: #fff;
+  --primary: #1e66f5;
+  --primary-foreground: #fff;
+  --secondary: #ccd0da;
+  --danger: #d20f39;
+  --success: #40a02b;
+  --warning: #df8e1d;
+  --trust: #8839ef;
+  --terminal: #eff1f5;
+  --terminal-text: #4c4f69;
+  --terminal-link: #1e66f5;
+  --terminal-link-visited: #8839ef;
 }
 
 * { box-sizing: border-box; }
@@ -406,8 +432,8 @@ textarea { min-height: 6.5rem; resize: vertical; }
   line-height: 1.45;
 }
 .activity-extract { background: var(--terminal); border: 1px solid var(--border); border-radius: .7rem; position: relative; }
-.term-content a.terminal-link { color: #80bfff; cursor: pointer; text-decoration: underline; text-decoration-color: color-mix(in srgb, currentColor 60%, transparent); text-underline-offset: .12em; }
-.term-content a.terminal-link:visited { color: #c8a2ff; }
+.term-content a.terminal-link { color: var(--terminal-link); cursor: pointer; text-decoration: underline; text-decoration-color: color-mix(in srgb, currentColor 60%, transparent); text-underline-offset: .12em; }
+.term-content a.terminal-link:visited { color: var(--terminal-link-visited); }
 .activity-extract pre { color: var(--terminal-text); margin: 0; max-height: 55dvh; overflow: auto; overflow-wrap: anywhere; padding: .8rem; padding-top: 2.4rem; white-space: pre-wrap; word-break: normal; }
 .activity-extract .empty-state { color: color-mix(in srgb, var(--terminal-text) 60%, transparent); padding: 1rem; }
 .copy-extract { color: var(--terminal-text); height: 2rem; min-height: 2rem; opacity: .65; position: absolute; right: .35rem; top: .35rem; width: 2rem; }

--- a/frontend/src/components/TerminalView.svelte
+++ b/frontend/src/components/TerminalView.svelte
@@ -26,7 +26,7 @@
     terminalRowOffsets,
     terminalSearchText,
   } from '$lib/terminal-find';
-  import { interfaceSize, terminalHeightLease } from '$lib/preferences';
+  import { interfaceSize, terminalHeightLease, theme } from '$lib/preferences';
   import { replaceView } from '$lib/router';
   import { securityState } from '$lib/security';
   import { relayStore } from '$lib/store';
@@ -337,6 +337,19 @@
     ];
     void highlightState;
     void tick().then(applyTerminalFindHighlights);
+  });
+
+  // The ANSI palette follows the theme's terminal scheme, so a theme change
+  // must repaint the cached frame rather than wait for the next output.
+  $effect(() => {
+    void $theme;
+    untrack(() => {
+      if (!lastContent) return;
+      const next = frame;
+      if (!next || next.paneId !== agent.pane_id) return;
+      lastContent = '';
+      void applyFrame(next, lastPreserveLayout, lastPreserveLineEnds);
+    });
   });
 
   $effect(() => {

--- a/frontend/src/lib/config.ts
+++ b/frontend/src/lib/config.ts
@@ -22,8 +22,20 @@ export const APP_PROTOCOL_VERSION = __APP_PROTOCOL_VERSION__;
 export const APP_VERSION = __APP_VERSION__;
 export const APP_ASSET_VERSION = __APP_ASSET_VERSION__;
 export const SERVICE_WORKER_URL = __SERVICE_WORKER_URL__;
-export const THEMES = ['dark', 'light', 'nord', 'solarized', 'rose'] as const;
+export const THEMES = ['dark', 'light', 'nord', 'solarized', 'rose', 'latte'] as const;
 export type Theme = (typeof THEMES)[number];
+// Terminal color scheme per theme. Every theme keeps a dark terminal pane by
+// default; a light-terminal theme renders the pane on a light background and
+// swaps the ANSI palette so the desktop's light-scheme output stays legible.
+export type TerminalScheme = 'dark' | 'light';
+export const THEME_TERMINAL_SCHEMES: Record<Theme, TerminalScheme> = {
+  dark: 'dark',
+  light: 'dark',
+  nord: 'dark',
+  solarized: 'dark',
+  rose: 'dark',
+  latte: 'light',
+};
 export const INTERFACE_SIZES = ['compact', 'regular', 'large'] as const;
 export type InterfaceSize = (typeof INTERFACE_SIZES)[number];
 export const TERMINAL_HISTORY_OPTIONS = [100, 500, 1_000] as const;
@@ -67,6 +79,7 @@ export const THEME_COLORS: Record<Theme, string> = {
   nord: '#2e3440',
   solarized: '#002b36',
   rose: '#191724',
+  latte: '#eff1f5',
 };
 
 export function relayLabelFromUrl(url: string): string {

--- a/frontend/src/lib/preferences.ts
+++ b/frontend/src/lib/preferences.ts
@@ -12,6 +12,7 @@ import {
   TERMINAL_REFRESH_OPTIONS,
   THEME_COLORS,
   THEME_KEY,
+  THEME_TERMINAL_SCHEMES,
   THEMES,
   type HomeLayout,
   type InterfaceSize,
@@ -19,6 +20,7 @@ import {
   type TerminalRefreshInterval,
   type Theme,
 } from './config';
+import { setTerminalScheme } from './terminal';
 
 function savedTheme(): Theme {
   const value = localStorage.getItem(THEME_KEY);
@@ -67,11 +69,16 @@ export const terminalHeightLease = writable<boolean>(
   localStorage.getItem(TERMINAL_HEIGHT_LEASE_KEY) === 'true',
 );
 
-export function setTheme(value: Theme): void {
-  localStorage.setItem(THEME_KEY, value);
-  theme.set(value);
+function applyTheme(value: Theme): void {
   document.documentElement.dataset.theme = value;
   document.querySelector<HTMLMetaElement>('meta[name="theme-color"]')?.setAttribute('content', THEME_COLORS[value]);
+  setTerminalScheme(THEME_TERMINAL_SCHEMES[value]);
+}
+
+export function setTheme(value: Theme): void {
+  localStorage.setItem(THEME_KEY, value);
+  applyTheme(value);
+  theme.set(value);
 }
 
 export function setInterfaceSize(value: InterfaceSize): void {
@@ -103,9 +110,6 @@ export function setHomeLayout(value: HomeLayout): void {
 
 
 export function initializePreferences(): void {
-  theme.subscribe((value) => {
-    document.documentElement.dataset.theme = value;
-    document.querySelector<HTMLMetaElement>('meta[name="theme-color"]')?.setAttribute('content', THEME_COLORS[value]);
-  })();
+  theme.subscribe(applyTheme)();
   interfaceSize.subscribe((value) => { document.documentElement.dataset.interfaceSize = value; })();
 }

--- a/frontend/src/lib/terminal.ts
+++ b/frontend/src/lib/terminal.ts
@@ -1,15 +1,63 @@
-const ANSI_COLORS: Record<number, string> = {
-  30: '#555', 31: '#ff5f5f', 32: '#5fd75f', 33: '#ffd75f',
-  34: '#5fafff', 35: '#d75fff', 36: '#1abc9c', 37: '#e5e5e5',
-  90: '#777', 91: '#ff8080', 92: '#80ff80', 93: '#ffff80',
-  94: '#80bfff', 95: '#ff80ff', 96: '#80ffff', 97: '#fff',
+import type { TerminalScheme } from './config';
+
+// Everything that depends on whether the phone's terminal pane is dark or
+// light. The desktop pane may run the opposite scheme, so each entry also says
+// which of its colors would vanish against this pane and need normalizing.
+interface TerminalSchemeSpec {
+  colors: Record<number, string>;
+  headingAccent: string;
+  // Replaces a row background painted for the opposite scheme.
+  rowFallback: string;
+  opposingBackground(color: string): boolean;
+  // Neutral text that disappears entirely takes the pane's text color.
+  vanishingText(channels: number[], spread: number): boolean;
+  // Tinted text that merely fades is mixed toward the pane's text color.
+  faintText(luminance: number): boolean;
+}
+
+const TERMINAL_SCHEMES: Record<TerminalScheme, TerminalSchemeSpec> = {
+  dark: {
+    colors: {
+      30: '#555', 31: '#ff5f5f', 32: '#5fd75f', 33: '#ffd75f',
+      34: '#5fafff', 35: '#d75fff', 36: '#1abc9c', 37: '#e5e5e5',
+      90: '#777', 91: '#ff8080', 92: '#80ff80', 93: '#ffff80',
+      94: '#80bfff', 95: '#ff80ff', 96: '#80ffff', 97: '#fff',
+    },
+    headingAccent: '#3daee9',
+    rowFallback: 'rgb(61,64,64)',
+    opposingBackground: isNearWhiteAnsiColor,
+    vanishingText: (channels, spread) => Math.max(...channels) <= 96 && spread <= 30,
+    faintText: (luminance) => luminance < 0.14,
+  },
+  // Catppuccin Latte's terminal palette, so a desktop on the matching light
+  // scheme reads the same on the phone.
+  light: {
+    colors: {
+      30: '#5c5f77', 31: '#d20f39', 32: '#40a02b', 33: '#df8e1d',
+      34: '#1e66f5', 35: '#ea76cb', 36: '#179299', 37: '#acb0be',
+      90: '#6c6f85', 91: '#de293e', 92: '#49af3d', 93: '#eea02d',
+      94: '#456eff', 95: '#fe85d8', 96: '#2d9fa8', 97: '#bcc0cc',
+    },
+    headingAccent: '#1e66f5',
+    rowFallback: 'rgb(204,208,218)',
+    opposingBackground: isNearBlackAnsiColor,
+    vanishingText: (channels, spread) => Math.min(...channels) >= 160 && spread <= 30,
+    faintText: (luminance) => luminance > 0.6,
+  },
 };
+
+// The renderer is pure over its text input; the active scheme is process-wide
+// state set from the theme preference. Terminal views repaint their cached
+// frame when it changes.
+let scheme = TERMINAL_SCHEMES.dark;
+
+export function setTerminalScheme(next: TerminalScheme): void {
+  scheme = TERMINAL_SCHEMES[next];
+}
 
 export const TERMINAL_SEPARATOR_TOKEN = '\uE000HERDR_SEPARATOR\uE000';
 export const TERMINAL_REPEATED_RUN_LIMIT = 24;
 const TERMINAL_REPEATED_RUN_TRIGGER = 32;
-const LIGHT_ROW_FALLBACK_BACKGROUND = 'rgb(61,64,64)';
-const ANSI_HEADING_ACCENT = '#3daee9';
 const TERMINAL_GRAPHEME_SEGMENTER = typeof Intl !== 'undefined' && 'Segmenter' in Intl
   ? new Intl.Segmenter(undefined, { granularity: 'grapheme' })
   : null;
@@ -516,8 +564,13 @@ function ansiRelativeLuminance(color: string): number | null {
   return 0.2126 * linear[0] + 0.7152 * linear[1] + 0.0722 * linear[2];
 }
 
+function isNearBlackAnsiColor(color: string): boolean {
+  const channels = ansiColorChannels(color);
+  return Boolean(channels && Math.max(...channels) <= 48 && Math.max(...channels) - Math.min(...channels) <= 24);
+}
+
 function normalizedAnsiBackground(color: string, normalize: boolean): string {
-  return normalize && isNearWhiteAnsiColor(color) ? LIGHT_ROW_FALLBACK_BACKGROUND : color;
+  return normalize && scheme.opposingBackground(color) ? scheme.rowFallback : color;
 }
 
 function normalizedAnsiForeground(color: string, normalize: boolean): string {
@@ -526,8 +579,8 @@ function normalizedAnsiForeground(color: string, normalize: boolean): string {
   const luminance = ansiRelativeLuminance(color);
   if (!channels || luminance === null) return color;
   const spread = Math.max(...channels) - Math.min(...channels);
-  if (Math.max(...channels) <= 96 && spread <= 30) return 'var(--terminal-text)';
-  if (luminance < 0.14) {
+  if (scheme.vanishingText(channels, spread)) return 'var(--terminal-text)';
+  if (scheme.faintText(luminance)) {
     return `color-mix(in srgb, ${color} 35%, var(--terminal-text))`;
   }
   return color;
@@ -536,8 +589,8 @@ function normalizedAnsiForeground(color: string, normalize: boolean): string {
 export function ansi256Color(index: number): string {
   const value = Number(index);
   if (!Number.isInteger(value) || value < 0 || value > 255) return '';
-  if (value < 8) return ANSI_COLORS[30 + value];
-  if (value < 16) return ANSI_COLORS[90 + value - 8];
+  if (value < 8) return scheme.colors[30 + value];
+  if (value < 16) return scheme.colors[90 + value - 8];
   if (value < 232) {
     const offset = value - 16;
     const levels = [0, 95, 135, 175, 215, 255];
@@ -617,14 +670,14 @@ export function ansiToHtml(
           else styles.backgroundColor = normalizedAnsiBackground(extended.color, normalizeNearWhiteBackground);
         }
         position += extended.consumed;
-      } else if (ANSI_COLORS[code]) {
-        styles.color = normalizedAnsiForeground(ANSI_COLORS[code], normalizeNearBlackForeground);
-      } else if (ANSI_COLORS[code - 10]) {
-        styles.backgroundColor = normalizedAnsiBackground(ANSI_COLORS[code - 10], normalizeNearWhiteBackground);
+      } else if (scheme.colors[code]) {
+        styles.color = normalizedAnsiForeground(scheme.colors[code], normalizeNearBlackForeground);
+      } else if (scheme.colors[code - 10]) {
+        styles.backgroundColor = normalizedAnsiBackground(scheme.colors[code - 10], normalizeNearWhiteBackground);
       }
     }
     const effective = styles.fontStyle === 'italic' && styles.fontWeight === '700' && !styles.color
-      ? { ...styles, color: ANSI_HEADING_ACCENT }
+      ? { ...styles, color: scheme.headingAccent }
       : styles;
     const style = Object.entries(effective).map(([name, value]) => `${ansiStyleName(name)}:${value}`).join(';');
     if (style) {
@@ -656,7 +709,7 @@ export function ansiLineBackground(line: string): string {
         const extended = ansiExtendedColor(codes, position);
         if (extended.color) background = extended.color;
         position += extended.consumed;
-      } else if (ANSI_COLORS[code - 10]) background = ANSI_COLORS[code - 10];
+      } else if (scheme.colors[code - 10]) background = scheme.colors[code - 10];
     }
   }
   return background;
@@ -677,7 +730,7 @@ export function ansiLineBackgroundIndent(line: string): number {
         position += ansiExtendedColor(codes, position).consumed;
         continue;
       }
-      if (code === 48 || ANSI_COLORS[code - 10]) {
+      if (code === 48 || scheme.colors[code - 10]) {
         return visiblePrefix.trim() ? 0 : visiblePrefix.replaceAll('\t', '    ').length;
       }
     }
@@ -823,7 +876,7 @@ export function terminalHtmlRows(
       ? (line.endsWith('\r') ? line.slice(0, -1) : line)
       : trimAnsiLineEnd(line);
     const sourceBackground = backgrounds[index];
-    const normalizeRow = normalizeLightPalette && isNearWhiteAnsiColor(sourceBackground);
+    const normalizeRow = normalizeLightPalette && scheme.opposingBackground(sourceBackground);
     const normalizeDarkText = normalizeLightPalette && (!sourceBackground || normalizeRow);
     const background = normalizedAnsiBackground(sourceBackground, normalizeRow);
     const renderedText = stripAnsi(renderedLine);

--- a/frontend/tests/unit/helpers.test.ts
+++ b/frontend/tests/unit/helpers.test.ts
@@ -39,6 +39,7 @@ import {
   latestCompletedResponse,
   renderTerminalContent,
   renderedRowShift,
+  setTerminalScheme,
   stripAnsi,
   TERMINAL_REPEATED_RUN_LIMIT,
   TERMINAL_SEPARATOR_TOKEN,
@@ -213,6 +214,30 @@ describe('terminal rendering', () => {
 
     const brightAccent = renderTerminalContent('\x1b[38;2;95;175;255mAccent\x1b[0m', 'ansi');
     expect(brightAccent.html).toContain('color:rgb(95,175,255)');
+  });
+
+  it('normalizes dark-origin ANSI colors onto a light mobile terminal', () => {
+    setTerminalScheme('light');
+    try {
+      const whiteText = renderTerminalContent('\x1b[38;2;229;229;229mMac text\x1b[0m', 'ansi');
+      expect(whiteText.html).toContain('color:var(--terminal-text)');
+
+      const paleYellow = renderTerminalContent('\x1b[38;2;255;255;128mPale text\x1b[0m', 'ansi');
+      expect(paleYellow.html).toContain('color:color-mix(in srgb, rgb(255,255,128) 35%, var(--terminal-text))');
+
+      const darkRow = renderTerminalContent('\x1b[48;2;8;8;8;38;2;229;229;229mDark terminal row\x1b[0m', 'ansi');
+      expect(darkRow.html).toContain('background-color:rgb(204,208,218)');
+      expect(darkRow.html).toContain('color:var(--terminal-text)');
+
+      const lightRow = renderTerminalContent('\x1b[48;2;250;250;250;38;2;20;20;20mLight terminal row\x1b[0m', 'ansi');
+      expect(lightRow.html).toContain('background-color:rgb(250,250,250)');
+      expect(lightRow.html).toContain('color:rgb(20,20,20)');
+
+      const basicRed = renderTerminalContent('\x1b[31mError\x1b[0m', 'ansi');
+      expect(basicRed.html).toContain('color:#d20f39');
+    } finally {
+      setTerminalScheme('dark');
+    }
   });
 
   it('limits blank gaps and merges separator fragments across whitespace', () => {


### PR DESCRIPTION
## What

Adds a `latte` theme (Catppuccin Latte) — the first theme whose terminal pane is light as well, so a desktop running the matching light scheme reads the same on the phone. The existing five themes are unchanged, including `light`, which keeps its dark terminal pane.

## Why the renderer changes

Every existing theme assumes a dark pane: the renderer normalizes the desktop's light-scheme ANSI output onto it (near-white row backgrounds → `rgb(61,64,64)`, near-black text → `--terminal-text`) and the 16-color palette includes `#e5e5e5` / `#fff`. Painting the pane light with only CSS therefore produced dark row bands and invisible text.

- `terminal.ts` gains a per-scheme table (`TERMINAL_SCHEMES`): ANSI palette, heading accent, the fallback row surface, and two predicates saying which colors from the *opposite* scheme would vanish against this pane. The light entry inverts the contrast normalization; the dark entry is the previous behavior verbatim.
- `config.ts` maps each theme to a terminal scheme (`THEME_TERMINAL_SCHEMES`); adding a theme forces the decision.
- `preferences.ts` applies the scheme with the theme; `TerminalView` repaints its cached frame on theme change instead of waiting for the next output.
- Terminal link colors become theme tokens (`--terminal-link`, `--terminal-link-visited`) with the previous values as defaults.

## Verification

- Unit test added for the light scheme (dark-origin rows and near-white text normalize; a light-origin row is kept; the basic red maps to Latte red). 260/260 unit, 75/75 chromium-mobile browser tests, `make frontend-check`.
- Screenshots at 430×932: latte terminal with all 16 colors, heading accent, link, dark-origin row fallback; nord unchanged.
- Note: the initial payload budget is now at gzip 129,772 / 130,048 B (+~430 B from the theme block and palette).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NRdayBsqfSrkrJQy4X9Z2v
