### PR TITLE
fix(question): include box-drawing corners and junctions in chromePattern

### DIFF
--- a/internal/question/attention_test.go
+++ b/internal/question/attention_test.go
@@ -29,6 +29,18 @@ $ npm test
 Esc to cancel · Enter to confirm
 `
 
+const claudeBoxedApprovalView = `
+╭────────────────────────────────────────╮
+│ Do you want to proceed?                 │
+│ Bash command                            │
+│ $ npm test                              │
+│ ❯ 1. Yes                                │
+│   2. Yes, and remember this choice      │
+│   3. No                                 │
+╰────────────────────────────────────────╯
+Esc to cancel · Enter to confirm
+`
+
 const claudePermissionView = `
 Claude needs your permission to use Bash.
 $ npm test
@@ -107,6 +119,7 @@ func TestClassifyLiveApprovalsByAgent(t *testing.T) {
 		{"codex tool", "codex", codexApprovalView, []string{"Approve", "Reject"}},
 		{"codex subagents", "codex", codexSubagentApprovalView, []string{"Approve all pending", "Configure individually", "Exit (cancel subagents)"}},
 		{"claude proceed", "claude", claudeApprovalView, []string{"Yes", "Yes, and remember this choice", "No"}},
+		{"claude boxed proceed", "claude", claudeBoxedApprovalView, []string{"Yes", "Yes, and remember this choice", "No"}},
 		{"claude permission", "claude", claudePermissionView, []string{"Allow once", "Reject"}},
 		{"qoder allow", "qodercli", qoderApprovalView, []string{"Allow", "Reject"}},
 		{"omp plan review", "omp", ompPlanApprovalView, []string{

--- a/internal/question/parser.go
+++ b/internal/question/parser.go
@@ -90,7 +90,7 @@ var (
 	otherPattern           = regexp.MustCompile(`(?i)^(?:type something\.?|type your own answer|none of the above|other)\b`)
 	selectedPattern        = regexp.MustCompile(`\s*[✓✔]\s*$`)
 	columnGapPattern       = regexp.MustCompile(`\s{2,}`)
-	chromePattern          = regexp.MustCompile(`(?i)^(?:[\s─━═_—│|◔◑◕●]+|.*\besc to cancel\b|.*\btype to queue\b|[◔◑◕●]\s+(?:shell|bash).*)$`)
+	chromePattern          = regexp.MustCompile(`(?i)^(?:[\s─━═_—│|┃┆┊╭╮╯╰├┤┬┴┼┌┐└┘]+|.*\besc to cancel\b|.*\btype to queue\b|[◔◑◕●]\s+(?:shell|bash).*)$`)
 	promptSkipPattern      = regexp.MustCompile(`(?i)^(?:bash command|do you want to proceed\??|would you like to run\b.*|environment:\s*\w+|press enter to confirm\b.*|esc to cancel\b.*)$`)
 	commandPattern         = regexp.MustCompile(`^\s*[$>❯›]\s+(.+?)\s*$`)
 	turnDurationPattern    = regexp.MustCompile(

--- a/internal/question/parser.go
+++ b/internal/question/parser.go
@@ -90,7 +90,7 @@ var (
 	otherPattern           = regexp.MustCompile(`(?i)^(?:type something\.?|type your own answer|none of the above|other)\b`)
 	selectedPattern        = regexp.MustCompile(`\s*[✓✔]\s*$`)
 	columnGapPattern       = regexp.MustCompile(`\s{2,}`)
-	chromePattern          = regexp.MustCompile(`(?i)^(?:[\s─━═_—│|┃┆┊╭╮╯╰├┤┬┴┼┌┐└┘]+|.*\besc to cancel\b|.*\btype to queue\b|[◔◑◕●]\s+(?:shell|bash).*)$`)
+	chromePattern          = regexp.MustCompile(`(?i)^(?:[\s─━═_—│|◔◑◕●┃┆┊╭╮╯╰├┤┬┴┼┌┐└┘]+|.*\besc to cancel\b|.*\btype to queue\b|[◔◑◕●]\s+(?:shell|bash).*)$`)
 	promptSkipPattern      = regexp.MustCompile(`(?i)^(?:bash command|do you want to proceed\??|would you like to run\b.*|environment:\s*\w+|press enter to confirm\b.*|esc to cancel\b.*)$`)
 	commandPattern         = regexp.MustCompile(`^\s*[$>❯›]\s+(.+?)\s*$`)
 	turnDurationPattern    = regexp.MustCompile(

--- a/internal/question/parser_test.go
+++ b/internal/question/parser_test.go
@@ -576,7 +576,7 @@ func stringReplace(value, old, replacement string) string {
 
 func TestChromePatternBoxDrawing(t *testing.T) {
 	cases := []string{
-		"─", "━", "═", "│", "|",
+		"─", "━", "═", "│", "|", "◔", "◑", "◕", "●",
 		"╭────────────────────────────────────────────╮",
 		"╰────────────────────────────────────────────╯",
 		"├────────────────────────────────────────────┤",
@@ -591,4 +591,3 @@ func TestChromePatternBoxDrawing(t *testing.T) {
 		}
 	}
 }
-

--- a/internal/question/parser_test.go
+++ b/internal/question/parser_test.go
@@ -573,3 +573,22 @@ func stringReplace(value, old, replacement string) string {
 	}
 	return value
 }
+
+func TestChromePatternBoxDrawing(t *testing.T) {
+	cases := []string{
+		"─", "━", "═", "│", "|",
+		"╭────────────────────────────────────────────╮",
+		"╰────────────────────────────────────────────╯",
+		"├────────────────────────────────────────────┤",
+		"┌────────────────────────────────────────────┐",
+		"└────────────────────────────────────────────┘",
+		"  ╭──────────────────────────────────────────╮  ",
+		"  ╰──────────────────────────────────────────╯  ",
+	}
+	for _, c := range cases {
+		if !chromePattern.MatchString(c) {
+			t.Errorf("chromePattern failed to match box drawing line: %q", c)
+		}
+	}
+}
+


### PR DESCRIPTION
### Summary

Expands \chromePattern\ in \internal/question/parser.go\ to include standard Unicode box-drawing corner and junction characters (\╭╮╯╰├┤┬┴┼┌┐└┘┃┆┊\).

### Problem

When modern CLI tools and interactive agents (such as Python Rich/Textual, Go Bubbletea, prompt_toolkit) format tool approval prompts or interactive questions using bordered panels:
\╭── Dangerous Command Approval ───────────────────╮
│  Execute: rm -rf /tmp/scratch                   │
│  [1] Allow once                                 │
│  [2] Allow for session                          │
│  [3] Reject                                     │
╰─────────────────────────────────────────────────╯
\ewerOutputAfterMenu()\ evaluates trailing lines after a detected menu to verify that subsequent terminal output hasn't moved past the prompt. It checks those lines against \chromePattern\.

Because \chromePattern\ previously only matched horizontal dashes and vertical bars (\[\s─━═_—│|◔◑◕●]+\), the closing line containing \╰\ and \╯\ failed the regex. The parser misidentified the closing box border as subsequent shell output arriving after the menu, which prematurely invalidated the menu and prevented the mobile UI from showing touch approval buttons.

### Solution

Includes standard box-drawing corners and junctions in \chromePattern\ so bordered dialog closures are recognized as terminal chrome. Added unit test \TestChromePatternBoxDrawing\.